### PR TITLE
Bump Python dependencies to latest

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
 sqlglot==30.10.0
-fastapi==0.115.2
-uvicorn==0.32.0
-requests==2.32.3
-pytz==2024.2
-looker-sdk==24.20.0
+fastapi==0.136.3
+uvicorn==0.49.0
+requests==2.34.2
+pytz==2026.2
+looker-sdk==26.10.0
 itsdangerous==2.2.0
-typer==0.12.5
+typer==0.26.7


### PR DESCRIPTION
## 概要
Python 依存(`requirements.txt`)を最新版へ更新。

| パッケージ | 旧 → 新 |
|---|---|
| fastapi | 0.115.2 → 0.136.3 |
| uvicorn | 0.32.0 → 0.49.0 |
| requests | 2.32.3 → 2.34.2 |
| pytz | 2024.2 → 2026.2 |
| looker-sdk | 24.20.0 → 26.10.0 |
| typer | 0.12.5 → 0.26.7 |
| sqlglot / itsdangerous | 据え置き(既に最新) |

推移的に starlette 1.2.1 / pydantic 2.13.4 / click 8.4.1。

## 検証(新 venv)
- アプリ起動: `/healthcheck`・`/api/v1/schemas`・静的HTML配信すべて 200(fastapi/uvicorn/starlette 1.x/SessionMiddleware OK)
- CLI: `run` / `run-params` / `version` が typer 0.26 で登録・動作
- `tools/looker_analyzer.py` が looker-sdk 26 で import 可能
- lineage 全モード(table/column × forward/reverse)が従来出力と一致(lineage は sqlglot 依存で不変)

## 補足
- フロント(npm: next 14→16, react 18→19 等)は別途・個別の高リスク作業として未着手。
- OAuth フローと run-params の実ファイル経由 E2E は本環境では未実行(認証情報/コンパイル済みSQL不在のため)だが、依存(requests/itsdangerous/sqlglot.diff)は互換確認済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)