### PR TITLE
chore: ignore __pycache__/ and *.pyc generally

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,9 +8,10 @@ out/*
 dist/*
 src/dbt_column_lineage/_version.py
 src/dbt_column_lineage.egg-info/*
-src/dbt_column_lineage/__pycache__/*
 dbt_project.yml
 target/*
 venv/*
 .venv/
 .DS_Store
+__pycache__/
+*.pyc


### PR DESCRIPTION
`.gitignore` の `src/dbt_column_lineage/__pycache__/*`(パス限定)を、一般形の `__pycache__/` + `*.pyc` に置き換え。`tools/__pycache__` などプロジェクト内のどのキャッシュも無視されるようにする。

追跡中の `.pyc`/`__pycache__` は無し(`git rm --cached` 不要)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)