### PR TITLE
refactor(frontend): migrate reactflow v11 → @xyflow/react v12 (Stage A)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@codemirror/lang-sql": "^6.8.0",
         "@uiw/react-codemirror": "^4.23.5",
+        "@xyflow/react": "^12.11.0",
         "clsx": "^2.1.1",
         "dagre": "^0.8.5",
         "html-to-image": "^1.11.11",
@@ -20,7 +21,6 @@
         "react-icons": "^5.3.0",
         "react-markdown": "^9.0.1",
         "react-select": "^5.8.1",
-        "reactflow": "^11.11.4",
         "remark-gfm": "^4.0.0"
       },
       "devDependencies": {
@@ -303,9 +303,9 @@
       }
     },
     "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
-      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -968,108 +968,6 @@
         "node": ">=14"
       }
     },
-    "node_modules/@reactflow/background": {
-      "version": "11.3.14",
-      "resolved": "https://registry.npmjs.org/@reactflow/background/-/background-11.3.14.tgz",
-      "integrity": "sha512-Gewd7blEVT5Lh6jqrvOgd4G6Qk17eGKQfsDXgyRSqM+CTwDqRldG2LsWN4sNeno6sbqVIC2fZ+rAUBFA9ZEUDA==",
-      "license": "MIT",
-      "dependencies": {
-        "@reactflow/core": "11.11.4",
-        "classcat": "^5.0.3",
-        "zustand": "^4.4.1"
-      },
-      "peerDependencies": {
-        "react": ">=17",
-        "react-dom": ">=17"
-      }
-    },
-    "node_modules/@reactflow/controls": {
-      "version": "11.2.14",
-      "resolved": "https://registry.npmjs.org/@reactflow/controls/-/controls-11.2.14.tgz",
-      "integrity": "sha512-MiJp5VldFD7FrqaBNIrQ85dxChrG6ivuZ+dcFhPQUwOK3HfYgX2RHdBua+gx+40p5Vw5It3dVNp/my4Z3jF0dw==",
-      "license": "MIT",
-      "dependencies": {
-        "@reactflow/core": "11.11.4",
-        "classcat": "^5.0.3",
-        "zustand": "^4.4.1"
-      },
-      "peerDependencies": {
-        "react": ">=17",
-        "react-dom": ">=17"
-      }
-    },
-    "node_modules/@reactflow/core": {
-      "version": "11.11.4",
-      "resolved": "https://registry.npmjs.org/@reactflow/core/-/core-11.11.4.tgz",
-      "integrity": "sha512-H4vODklsjAq3AMq6Np4LE12i1I4Ta9PrDHuBR9GmL8uzTt2l2jh4CiQbEMpvMDcp7xi4be0hgXj+Ysodde/i7Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/d3": "^7.4.0",
-        "@types/d3-drag": "^3.0.1",
-        "@types/d3-selection": "^3.0.3",
-        "@types/d3-zoom": "^3.0.1",
-        "classcat": "^5.0.3",
-        "d3-drag": "^3.0.0",
-        "d3-selection": "^3.0.0",
-        "d3-zoom": "^3.0.0",
-        "zustand": "^4.4.1"
-      },
-      "peerDependencies": {
-        "react": ">=17",
-        "react-dom": ">=17"
-      }
-    },
-    "node_modules/@reactflow/minimap": {
-      "version": "11.7.14",
-      "resolved": "https://registry.npmjs.org/@reactflow/minimap/-/minimap-11.7.14.tgz",
-      "integrity": "sha512-mpwLKKrEAofgFJdkhwR5UQ1JYWlcAAL/ZU/bctBkuNTT1yqV+y0buoNVImsRehVYhJwffSWeSHaBR5/GJjlCSQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@reactflow/core": "11.11.4",
-        "@types/d3-selection": "^3.0.3",
-        "@types/d3-zoom": "^3.0.1",
-        "classcat": "^5.0.3",
-        "d3-selection": "^3.0.0",
-        "d3-zoom": "^3.0.0",
-        "zustand": "^4.4.1"
-      },
-      "peerDependencies": {
-        "react": ">=17",
-        "react-dom": ">=17"
-      }
-    },
-    "node_modules/@reactflow/node-resizer": {
-      "version": "2.2.14",
-      "resolved": "https://registry.npmjs.org/@reactflow/node-resizer/-/node-resizer-2.2.14.tgz",
-      "integrity": "sha512-fwqnks83jUlYr6OHcdFEedumWKChTHRGw/kbCxj0oqBd+ekfs+SIp4ddyNU0pdx96JIm5iNFS0oNrmEiJbbSaA==",
-      "license": "MIT",
-      "dependencies": {
-        "@reactflow/core": "11.11.4",
-        "classcat": "^5.0.4",
-        "d3-drag": "^3.0.0",
-        "d3-selection": "^3.0.0",
-        "zustand": "^4.4.1"
-      },
-      "peerDependencies": {
-        "react": ">=17",
-        "react-dom": ">=17"
-      }
-    },
-    "node_modules/@reactflow/node-toolbar": {
-      "version": "1.3.14",
-      "resolved": "https://registry.npmjs.org/@reactflow/node-toolbar/-/node-toolbar-1.3.14.tgz",
-      "integrity": "sha512-rbynXQnH/xFNu4P9H+hVqlEUafDCkEoCy0Dg9mG22Sg+rY/0ck6KkrAQrYrTgXusd+cEJOMK0uOOFCK2/5rSGQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@reactflow/core": "11.11.4",
-        "classcat": "^5.0.3",
-        "zustand": "^4.4.1"
-      },
-      "peerDependencies": {
-        "react": ">=17",
-        "react-dom": ">=17"
-      }
-    },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
@@ -1111,100 +1009,10 @@
         "tslib": "^2.4.0"
       }
     },
-    "node_modules/@types/d3": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/@types/d3/-/d3-7.4.3.tgz",
-      "integrity": "sha512-lZXZ9ckh5R8uiFVt8ogUNf+pIrK4EsWrx2Np75WvF/eTpJ0FMHNhjXk8CKEx/+gpHbNQyJWehbFaTvqmHWB3ww==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/d3-array": "*",
-        "@types/d3-axis": "*",
-        "@types/d3-brush": "*",
-        "@types/d3-chord": "*",
-        "@types/d3-color": "*",
-        "@types/d3-contour": "*",
-        "@types/d3-delaunay": "*",
-        "@types/d3-dispatch": "*",
-        "@types/d3-drag": "*",
-        "@types/d3-dsv": "*",
-        "@types/d3-ease": "*",
-        "@types/d3-fetch": "*",
-        "@types/d3-force": "*",
-        "@types/d3-format": "*",
-        "@types/d3-geo": "*",
-        "@types/d3-hierarchy": "*",
-        "@types/d3-interpolate": "*",
-        "@types/d3-path": "*",
-        "@types/d3-polygon": "*",
-        "@types/d3-quadtree": "*",
-        "@types/d3-random": "*",
-        "@types/d3-scale": "*",
-        "@types/d3-scale-chromatic": "*",
-        "@types/d3-selection": "*",
-        "@types/d3-shape": "*",
-        "@types/d3-time": "*",
-        "@types/d3-time-format": "*",
-        "@types/d3-timer": "*",
-        "@types/d3-transition": "*",
-        "@types/d3-zoom": "*"
-      }
-    },
-    "node_modules/@types/d3-array": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
-      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
-      "license": "MIT"
-    },
-    "node_modules/@types/d3-axis": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/@types/d3-axis/-/d3-axis-3.0.6.tgz",
-      "integrity": "sha512-pYeijfZuBd87T0hGn0FO1vQ/cgLk6E1ALJjfkC0oJ8cbwkZl3TpgS8bVBLZN+2jjGgg38epgxb2zmoGtSfvgMw==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/d3-selection": "*"
-      }
-    },
-    "node_modules/@types/d3-brush": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/@types/d3-brush/-/d3-brush-3.0.6.tgz",
-      "integrity": "sha512-nH60IZNNxEcrh6L1ZSMNA28rj27ut/2ZmI3r96Zd+1jrZD++zD3LsMIjWlvg4AYrHn/Pqz4CF3veCxGjtbqt7A==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/d3-selection": "*"
-      }
-    },
-    "node_modules/@types/d3-chord": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/@types/d3-chord/-/d3-chord-3.0.6.tgz",
-      "integrity": "sha512-LFYWWd8nwfwEmTZG9PfQxd17HbNPksHBiJHaKuY1XeqscXacsS2tyoo6OdRsjf+NQYeB6XrNL3a25E3gH69lcg==",
-      "license": "MIT"
-    },
     "node_modules/@types/d3-color": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
       "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
-      "license": "MIT"
-    },
-    "node_modules/@types/d3-contour": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/@types/d3-contour/-/d3-contour-3.0.6.tgz",
-      "integrity": "sha512-BjzLgXGnCWjUSYGfH1cpdo41/hgdWETu4YxpezoztawmqsvCeep+8QGfiY6YbDvfgHz/DkjeIkkZVJavB4a3rg==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/d3-array": "*",
-        "@types/geojson": "*"
-      }
-    },
-    "node_modules/@types/d3-delaunay": {
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/@types/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
-      "integrity": "sha512-ZMaSKu4THYCU6sV64Lhg6qjf1orxBthaC161plr5KuPHo3CNm8DTHiLw/5Eq2b6TsNP0W0iJrUOFscY6Q450Hw==",
-      "license": "MIT"
-    },
-    "node_modules/@types/d3-dispatch": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/@types/d3-dispatch/-/d3-dispatch-3.0.7.tgz",
-      "integrity": "sha512-5o9OIAdKkhN1QItV2oqaE5KMIiXAvDWBDPrD85e58Qlz1c1kI/J0NcqbEG88CoTwJrYe7ntUCVfeUl2UJKbWgA==",
       "license": "MIT"
     },
     "node_modules/@types/d3-drag": {
@@ -1216,54 +1024,6 @@
         "@types/d3-selection": "*"
       }
     },
-    "node_modules/@types/d3-dsv": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/@types/d3-dsv/-/d3-dsv-3.0.7.tgz",
-      "integrity": "sha512-n6QBF9/+XASqcKK6waudgL0pf/S5XHPPI8APyMLLUHd8NqouBGLsU8MgtO7NINGtPBtk9Kko/W4ea0oAspwh9g==",
-      "license": "MIT"
-    },
-    "node_modules/@types/d3-ease": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
-      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
-      "license": "MIT"
-    },
-    "node_modules/@types/d3-fetch": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/@types/d3-fetch/-/d3-fetch-3.0.7.tgz",
-      "integrity": "sha512-fTAfNmxSb9SOWNB9IoG5c8Hg6R+AzUHDRlsXsDZsNp6sxAEOP0tkP3gKkNSO/qmHPoBFTxNrjDprVHDQDvo5aA==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/d3-dsv": "*"
-      }
-    },
-    "node_modules/@types/d3-force": {
-      "version": "3.0.10",
-      "resolved": "https://registry.npmjs.org/@types/d3-force/-/d3-force-3.0.10.tgz",
-      "integrity": "sha512-ZYeSaCF3p73RdOKcjj+swRlZfnYpK1EbaDiYICEEp5Q6sUiqFaFQ9qgoshp5CzIyyb/yD09kD9o2zEltCexlgw==",
-      "license": "MIT"
-    },
-    "node_modules/@types/d3-format": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@types/d3-format/-/d3-format-3.0.4.tgz",
-      "integrity": "sha512-fALi2aI6shfg7vM5KiR1wNJnZ7r6UuggVqtDA+xiEdPZQwy/trcQaHnwShLuLdta2rTymCNpxYTiMZX/e09F4g==",
-      "license": "MIT"
-    },
-    "node_modules/@types/d3-geo": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@types/d3-geo/-/d3-geo-3.1.0.tgz",
-      "integrity": "sha512-856sckF0oP/diXtS4jNsiQw/UuK5fQG8l/a9VVLeSouf1/PPbBE1i1W852zVwKwYCBkFJJB7nCFTbk6UMEXBOQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/geojson": "*"
-      }
-    },
-    "node_modules/@types/d3-hierarchy": {
-      "version": "3.1.7",
-      "resolved": "https://registry.npmjs.org/@types/d3-hierarchy/-/d3-hierarchy-3.1.7.tgz",
-      "integrity": "sha512-tJFtNoYBtRtkNysX1Xq4sxtjK8YgoWUNpIiUee0/jHGRwqvzYxkq0hGVbbOGSz+JgFxxRu4K8nb3YpG3CMARtg==",
-      "license": "MIT"
-    },
     "node_modules/@types/d3-interpolate": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
@@ -1273,76 +1033,10 @@
         "@types/d3-color": "*"
       }
     },
-    "node_modules/@types/d3-path": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
-      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
-      "license": "MIT"
-    },
-    "node_modules/@types/d3-polygon": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@types/d3-polygon/-/d3-polygon-3.0.2.tgz",
-      "integrity": "sha512-ZuWOtMaHCkN9xoeEMr1ubW2nGWsp4nIql+OPQRstu4ypeZ+zk3YKqQT0CXVe/PYqrKpZAi+J9mTs05TKwjXSRA==",
-      "license": "MIT"
-    },
-    "node_modules/@types/d3-quadtree": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/@types/d3-quadtree/-/d3-quadtree-3.0.6.tgz",
-      "integrity": "sha512-oUzyO1/Zm6rsxKRHA1vH0NEDG58HrT5icx/azi9MF1TWdtttWl0UIUsjEQBBh+SIkrpd21ZjEv7ptxWys1ncsg==",
-      "license": "MIT"
-    },
-    "node_modules/@types/d3-random": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@types/d3-random/-/d3-random-3.0.3.tgz",
-      "integrity": "sha512-Imagg1vJ3y76Y2ea0871wpabqp613+8/r0mCLEBfdtqC7xMSfj9idOnmBYyMoULfHePJyxMAw3nWhJxzc+LFwQ==",
-      "license": "MIT"
-    },
-    "node_modules/@types/d3-scale": {
-      "version": "4.0.9",
-      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
-      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/d3-time": "*"
-      }
-    },
-    "node_modules/@types/d3-scale-chromatic": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@types/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
-      "integrity": "sha512-iWMJgwkK7yTRmWqRB5plb1kadXyQ5Sj8V/zYlFGMUBbIPKQScw+Dku9cAAMgJG+z5GYDoMjWGLVOvjghDEFnKQ==",
-      "license": "MIT"
-    },
     "node_modules/@types/d3-selection": {
       "version": "3.0.11",
       "resolved": "https://registry.npmjs.org/@types/d3-selection/-/d3-selection-3.0.11.tgz",
       "integrity": "sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==",
-      "license": "MIT"
-    },
-    "node_modules/@types/d3-shape": {
-      "version": "3.1.8",
-      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
-      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/d3-path": "*"
-      }
-    },
-    "node_modules/@types/d3-time": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
-      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
-      "license": "MIT"
-    },
-    "node_modules/@types/d3-time-format": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/@types/d3-time-format/-/d3-time-format-4.0.3.tgz",
-      "integrity": "sha512-5xg9rC+wWL8kdDj153qZcsJ0FWiFt0J5RB6LYUNZjwSnesfblqrI/bJ1wBdJ8OQfncgbJG5+2F+qfqnqyzYxyg==",
-      "license": "MIT"
-    },
-    "node_modules/@types/d3-timer": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
-      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
       "license": "MIT"
     },
     "node_modules/@types/d3-transition": {
@@ -1394,12 +1088,6 @@
       "dependencies": {
         "@types/estree": "*"
       }
-    },
-    "node_modules/@types/geojson": {
-      "version": "7946.0.16",
-      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
-      "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
-      "license": "MIT"
     },
     "node_modules/@types/hast": {
       "version": "3.0.4",
@@ -1469,8 +1157,9 @@
       "version": "18.3.7",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
       "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^18.0.0"
       }
@@ -2103,6 +1792,40 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@unrs/resolver-binding-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@unrs/resolver-binding-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@unrs/resolver-binding-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@unrs/resolver-binding-win32-arm64-msvc": {
       "version": "1.12.2",
       "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-arm64-msvc/-/resolver-binding-win32-arm64-msvc-1.12.2.tgz",
@@ -2144,6 +1867,48 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@xyflow/react": {
+      "version": "12.11.0",
+      "resolved": "https://registry.npmjs.org/@xyflow/react/-/react-12.11.0.tgz",
+      "integrity": "sha512-na4IO33FSs2OS72hASgZDmTYwFAkef7Z74uBUVrong3ARmQQHfnRUVaCFn1kTt5LbS6pK03TbYjCPGLjLFfziA==",
+      "license": "MIT",
+      "dependencies": {
+        "@xyflow/system": "0.0.77",
+        "classcat": "^5.0.3",
+        "zustand": "^4.4.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=17",
+        "@types/react-dom": ">=17",
+        "react": ">=17",
+        "react-dom": ">=17"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@xyflow/system": {
+      "version": "0.0.77",
+      "resolved": "https://registry.npmjs.org/@xyflow/system/-/system-0.0.77.tgz",
+      "integrity": "sha512-qCDCMCQAAgUu8yHnhloHG9F5mwPX5E+Wl8McpYIOPSSXfzFJJoZcwOcsDiAjitVKIg2de1WmJbCHfpcvxprsgg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-drag": "^3.0.7",
+        "@types/d3-interpolate": "^3.0.4",
+        "@types/d3-selection": "^3.0.10",
+        "@types/d3-transition": "^3.0.8",
+        "@types/d3-zoom": "^3.0.8",
+        "d3-drag": "^3.0.0",
+        "d3-interpolate": "^3.0.1",
+        "d3-selection": "^3.0.0",
+        "d3-zoom": "^3.0.0"
+      }
     },
     "node_modules/acorn": {
       "version": "8.16.0",
@@ -3724,6 +3489,7 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -7264,24 +7030,6 @@
       "peerDependencies": {
         "react": ">=16.6.0",
         "react-dom": ">=16.6.0"
-      }
-    },
-    "node_modules/reactflow": {
-      "version": "11.11.4",
-      "resolved": "https://registry.npmjs.org/reactflow/-/reactflow-11.11.4.tgz",
-      "integrity": "sha512-70FOtJkUWH3BAOsN+LU9lCrKoKbtOPnz2uq0CV2PLdNSwxTXOhCbsZr50GmZ+Rtw3jx8Uv7/vBFtCGixLfd4Og==",
-      "license": "MIT",
-      "dependencies": {
-        "@reactflow/background": "11.3.14",
-        "@reactflow/controls": "11.2.14",
-        "@reactflow/core": "11.11.4",
-        "@reactflow/minimap": "11.7.14",
-        "@reactflow/node-resizer": "2.2.14",
-        "@reactflow/node-toolbar": "1.3.14"
-      },
-      "peerDependencies": {
-        "react": ">=17",
-        "react-dom": ">=17"
       }
     },
     "node_modules/read-cache": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -21,7 +21,7 @@
     "react-icons": "^5.3.0",
     "react-markdown": "^9.0.1",
     "react-select": "^5.8.1",
-    "reactflow": "^11.11.4",
+    "@xyflow/react": "^12.11.0",
     "remark-gfm": "^4.0.0"
   },
   "devDependencies": {

--- a/frontend/src/components/molecules/CteNode.tsx
+++ b/frontend/src/components/molecules/CteNode.tsx
@@ -1,11 +1,7 @@
 import React, { useCallback, useEffect } from 'react'
-import { Handle, Position, NodeProps } from 'reactflow'
+import { Node, Handle, Position, NodeProps } from '@xyflow/react'
 
-export interface CteNodeProps extends NodeProps {
-  data: CteData
-}
-
-interface CteData {
+type CteData = {
   label: string
   nodeType: string
   meta: Meta[]
@@ -15,6 +11,9 @@ interface CteData {
   unions?: string[]
   joins?: string[]
 }
+
+export type CteNodeType = Node<CteData, 'cteNode'>
+export type CteNodeProps = NodeProps<CteNodeType>
 
 export interface Meta {
   column: string

--- a/frontend/src/components/molecules/DashboardNode.tsx
+++ b/frontend/src/components/molecules/DashboardNode.tsx
@@ -1,6 +1,6 @@
 'use client'
 import React, { useCallback } from 'react'
-import { NodeProps, Position } from 'reactflow'
+import { Node, NodeProps, Position } from '@xyflow/react'
 import { useStore as useStoreZustand } from '@/store/zustand'
 import { useEventNodeOperations } from '@/hooks/useEventNodeOperations'
 import TableNodeColumnHandle from '@/components/molecules/TableNodeColumnHandle'
@@ -8,11 +8,7 @@ import DashboardNodeFrame from '@/components/molecules/DashboardNodeFrame'
 import TableNodeHandle from '@/components/molecules/TableNodeHandle'
 
 
-export interface DashboardNodeProps extends NodeProps {
-  data: DashboardNodeType
-}
-
-interface DashboardNodeType {
+type DashboardNodeType = {
   id: string
   name: string
   url: string
@@ -20,6 +16,9 @@ interface DashboardNodeType {
   first: boolean
   last: boolean
 }
+
+export type DashboardNodeFlowType = Node<DashboardNodeType, 'dashboardNode'>
+export type DashboardNodeProps = NodeProps<DashboardNodeFlowType>
 interface DashboardElementType {
   id: string
   title: string

--- a/frontend/src/components/molecules/TableNode.tsx
+++ b/frontend/src/components/molecules/TableNode.tsx
@@ -1,6 +1,6 @@
 'use client'
 import React, { useCallback } from 'react'
-import { NodeProps, Position } from 'reactflow'
+import { Node, NodeProps, Position } from '@xyflow/react'
 import { useStore as useStoreZustand } from '@/store/zustand'
 import { useEventNodeOperations } from '@/hooks/useEventNodeOperations'
 import EventNodeHandle from '@/components/molecules/TableNodeColumnHandle'
@@ -8,11 +8,7 @@ import EventNodeFrame from '@/components/molecules/TableNodeFrame'
 import TableNodeMoreColumns from '@/components/molecules/TableNodeMoreColumns'
 import TableNodeHandle from '@/components/molecules/TableNodeHandle'
 
-export interface TableNodeProps extends NodeProps {
-  data: TableNodeDataType
-}
-
-interface TableNodeDataType {
+type TableNodeDataType = {
   name: string
   color: string
   schema: string
@@ -21,6 +17,9 @@ interface TableNodeDataType {
   first: boolean
   last: boolean
 }
+
+export type TableNodeType = Node<TableNodeDataType, 'tableNode'>
+export type TableNodeProps = NodeProps<TableNodeType>
 
 
 export const TableNode: React.FC<TableNodeProps> = ({ data, id, selected }) => {

--- a/frontend/src/components/molecules/TableNodeColumnHandle.tsx
+++ b/frontend/src/components/molecules/TableNodeColumnHandle.tsx
@@ -1,6 +1,6 @@
 'use client'
 import React, { memo } from 'react'
-import { Handle, Position, useStore } from 'reactflow'
+import { Handle, Position, useStore } from '@xyflow/react'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faMinus, faPlus, faSpinner } from '@fortawesome/free-solid-svg-icons'
 import { useStore as useStoreZustand } from '@/store/zustand'

--- a/frontend/src/components/molecules/TableNodeHandle.tsx
+++ b/frontend/src/components/molecules/TableNodeHandle.tsx
@@ -1,6 +1,6 @@
 'use client'
 import React, { memo } from 'react'
-import { Handle, Position, useStore } from 'reactflow'
+import { Handle, Position, useStore } from '@xyflow/react'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faMinus, faPlus, faSpinner } from '@fortawesome/free-solid-svg-icons'
 import { useStore as useStoreZustand } from '@/store/zustand'

--- a/frontend/src/components/organisms/Sidebar.tsx
+++ b/frontend/src/components/organisms/Sidebar.tsx
@@ -1,7 +1,7 @@
 'use client'
 import { useRouter } from 'next/navigation'
 import { useCallback, useEffect, useState } from 'react'
-import { Edge, Node, Position, ReactFlowState, useReactFlow, useStore } from 'reactflow'
+import { Edge, Node, Position, ReactFlowState, useReactFlow, useStore } from '@xyflow/react'
 import { useStore as useStoreZustand } from '@/store/zustand'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faAngleRight, faAngleLeft } from '@fortawesome/free-solid-svg-icons'
@@ -25,8 +25,8 @@ const getLayoutedElements = (nodes: Node[], edges: Edge[], options: {rankdir: st
   edges.forEach((edge) => dagreGraph.setEdge(edge.source, edge.target))
   nodes.forEach((node) => dagreGraph.setNode(node.id, {
     label: node.id,
-    width: node.width,
-    height: node.height,
+    width: node.measured?.width,
+    height: node.measured?.height,
   }))
 
   dagre.layout(dagreGraph)
@@ -65,7 +65,7 @@ const getLayoutedElements = (nodes: Node[], edges: Edge[], options: {rankdir: st
 
 export const Sidebar = ({setNodes, setEdges, setViewIsFit, nodesPositioned, setNodesPositioned}: DagreNodePositioningProps) => {
   const { fitView } = useReactFlow()
-  const nodeInternals = useStore((state: ReactFlowState) => state.nodeInternals)
+  const nodeInternals = useStore((state: ReactFlowState) => state.nodeLookup)
   const flattenedNodes = Array.from(nodeInternals.values())
   const edges = useStore((state: ReactFlowState) => state.edges)
   const transform = useStore((state: ReactFlowState) => state.transform)
@@ -75,8 +75,8 @@ export const Sidebar = ({setNodes, setEdges, setViewIsFit, nodesPositioned, setN
   const router = useRouter()
 
   const goToCte = useCallback((node: Node, column: string) => {
-    const schema = node.data.schema
-    const source = node.data.name
+    const schema = String(node.data.schema)
+    const source = String(node.data.name)
     const query = new URLSearchParams({schema, source, column})
 
     router.push(`/cte?${query.toString()}`)
@@ -85,7 +85,7 @@ export const Sidebar = ({setNodes, setEdges, setViewIsFit, nodesPositioned, setN
   useEffect(() => {
     try {
       // node dimensions are not immediately detected, so we want to wait until they are
-      if (flattenedNodes[0]?.width) {
+      if (flattenedNodes[0]?.measured?.width) {
 
         // use dagre graph to layout nodes
 
@@ -128,7 +128,7 @@ export const Sidebar = ({setNodes, setEdges, setViewIsFit, nodesPositioned, setN
         {flattenedNodes.map((node) => (
           <div key={node.id}>
             <span
-                  className="font-medium break-words">{node.data.name}</span>
+                  className="font-medium break-words">{String(node.data.name)}</span>
             <div>x: {node.position.x.toFixed(2)}, y: {node.position.y.toFixed(2)}</div>
             {/*<ul className="list-disc px-4">*/}
             {/*  {node.data.columns.map((column: string, index: number) => (*/}

--- a/frontend/src/components/pages/Cl.tsx
+++ b/frontend/src/components/pages/Cl.tsx
@@ -3,21 +3,24 @@ import { useSearchParams } from 'next/navigation'
 import { TableNode, TableNodeProps } from '@/components/molecules/TableNode'
 import { useGetWindowSize } from '@/hooks/useGetWindowSize'
 import React, { useCallback, useEffect, useMemo, useState } from 'react'
-import ReactFlow, {
+import {
+  ReactFlow,
   addEdge,
   applyEdgeChanges,
   applyNodeChanges,
   Background,
   Connection,
   Controls,
+  Edge,
   EdgeChange,
+  Node,
   NodeChange,
   Panel,
   ReactFlowProvider,
   useEdgesState,
   useNodesState,
-} from 'reactflow'
-import 'reactflow/dist/style.css'
+} from '@xyflow/react'
+import '@xyflow/react/dist/style.css'
 
 import { Sidebar } from '@/components/organisms/Sidebar'
 import { Header } from '@/components/organisms/Header'
@@ -38,8 +41,8 @@ interface QueryParams {
 export const Cl = () => {
   const { height: windowHeight, width: windowWidth } = useGetWindowSize()
 
-  const [nodes, setNodes] = useNodesState([])
-  const [edges, setEdges] = useEdgesState([])
+  const [nodes, setNodes] = useNodesState<Node>([])
+  const [edges, setEdges] = useEdgesState<Edge>([])
   const [viewIsFit, setViewIsFit] = useState(false)
   const [nodesPositioned, setNodesPositioned] = useState(true)
 

--- a/frontend/src/components/pages/Cte.tsx
+++ b/frontend/src/components/pages/Cte.tsx
@@ -2,10 +2,10 @@
 import { useRouter, useSearchParams } from 'next/navigation'
 import { useGetWindowSize } from '@/hooks/useGetWindowSize'
 import React, { Suspense, useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import ReactFlow, { addEdge, applyEdgeChanges, applyNodeChanges, Background, Connection, Controls,
+import { ReactFlow, addEdge, applyEdgeChanges, applyNodeChanges, Background, Connection, Controls,
   Edge, EdgeChange, Node, NodeChange, ReactFlowProvider, useEdgesState, useNodesState, useReactFlow
-} from 'reactflow'
-import 'reactflow/dist/style.css'
+} from '@xyflow/react'
+import '@xyflow/react/dist/style.css'
 
 import { Header } from '@/components/organisms/Header'
 import { useStore as useStoreZustand } from '@/store/zustand'
@@ -49,8 +49,8 @@ const getLayoutedElements = (nodes: Node[], edges: Edge[], options: {rankdir: st
   edges.forEach((edge) => dagreGraph.setEdge(edge.source, edge.target))
   nodes.forEach((node) => dagreGraph.setNode(node.id, {
     label: node.id,
-    width: node.width,
-    height: node.height,
+    width: node.measured?.width,
+    height: node.measured?.height,
   }))
 
   dagre.layout(dagreGraph)

--- a/frontend/src/components/ui/ToggleButtons.tsx
+++ b/frontend/src/components/ui/ToggleButtons.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect, useState } from 'react'
 import { useStore as useStoreZustand } from '@/store/zustand'
-import { Edge, useReactFlow } from 'reactflow'
+import { Edge, useReactFlow } from '@xyflow/react'
 import { toBlob } from 'html-to-image'
 import { Camera, Table, Columns3 } from 'lucide-react'
 

--- a/frontend/src/hooks/useEventNodeOperations.ts
+++ b/frontend/src/hooks/useEventNodeOperations.ts
@@ -1,5 +1,5 @@
 import { useCallback, useState } from 'react'
-import { Node, Edge, useReactFlow, useUpdateNodeInternals, getConnectedEdges } from 'reactflow'
+import { Node, Edge, useReactFlow, useUpdateNodeInternals, getConnectedEdges } from '@xyflow/react'
 import { useStore as useStoreZustand } from '@/store/zustand'
 
 export const useEventNodeOperations = (id: string) => {
@@ -31,7 +31,10 @@ export const useEventNodeOperations = (id: string) => {
           data: {
             ...existingNode.data,
             ...newNode.data,
-            columns: Array.from(new Set([...existingNode.data.columns, ...newNode.data.columns]))
+            columns: Array.from(new Set([
+              ...(existingNode.data.columns as string[]),
+              ...(newNode.data.columns as string[]),
+            ]))
           }
         })
       } else {
@@ -223,7 +226,7 @@ export const useEventNodeOperations = (id: string) => {
         }
         const columnsToRemove = columnMappings.get(node.id) || new Set<string>()
         //  削除すべきカラムを除外したカラムリストを取得
-        const updatedColumns = node.data.columns.filter((col: string) => !columnsToRemove.has(col))
+        const updatedColumns = (node.data.columns as string[]).filter((col: string) => !columnsToRemove.has(col))
 
         // 更新されたノード情報を返す
         return {
@@ -232,7 +235,7 @@ export const useEventNodeOperations = (id: string) => {
         }
       }).filter(node =>
         // クリックされたノード、またはカラムが1つ以上ある、または固定されたエッジを持つノードのみを残す
-        node.id === nodeId || node.data.columns.length > 0 || fixedEdges.has(node.id)
+        node.id === nodeId || (node.data.columns as string[]).length > 0 || fixedEdges.has(node.id)
       )
     })
 

--- a/frontend/src/store/zustand.ts
+++ b/frontend/src/store/zustand.ts
@@ -1,5 +1,5 @@
 import { create } from 'zustand'
-import { Edge } from 'reactflow'
+import { Edge } from '@xyflow/react'
 
 export type SourceModeType = 'dbt' | 'looker'
 type MessageType = 'success' | 'error' | 'info'


### PR DESCRIPTION
フロント メジャーアップグレードの **ステージA**。react 18 / next 14 のまま、`reactflow` → `@xyflow/react` v12 へ移行します。

## 変更点

| 変更 | 内容 |
|---|---|
| パッケージ | `reactflow ^11.11.4` → `@xyflow/react ^12.11.0`、CSS パス `@xyflow/react/dist/style.css` |
| `ReactFlow` | default → 名前付き export(Cl/Cte) |
| ストア state | `nodeInternals` → `nodeLookup`(Sidebar) |
| 測定寸法 | `node.width/height` → `node.measured?.width/height`(dagre レイアウトと配置準備ガード) |
| `NodeProps` | ジェネリック化対応: `interface X extends NodeProps { data }` → `type Data = {...}; NodeProps<Node<Data,'type'>>`(interface は `Record<string,unknown>` に非代入のため) |
| フック型付け | `useNodesState<Node>([])` / `useEdgesState<Edge>([])` |
| `node.data` | `any` → `unknown` になったため `columns` をキャスト・`String()` 強制 |

## 検証(Playwright 実機 + `npm run build`)

- `/cl` テーブル: dagre でノード分散配置・エッジ正常
- `/cl` カラムトグル: 列レベル描画・ハンドル・`store.edges` セレクタ
- ノード非表示: `useReactFlow`/`getConnectedEdges` 経路・再レイアウト
- `/cte`: SQL ハイライト + CTE 依存グラフ(TB レイアウト)
- コンソールエラー 0件、静的エクスポート(`out/cl.html`・`cte.html`)生成OK

ステージB(next 16 + react 19)は別PRで対応予定。

🤖 Generated with [Claude Code](https://claude.com/claude-code)