### PR TITLE
refactor(frontend): resolve all 50 react-hooks lint warnings

### DIFF
--- a/frontend/src/components/molecules/DashboardNode.tsx
+++ b/frontend/src/components/molecules/DashboardNode.tsx
@@ -32,7 +32,7 @@ export const DashboardNode: React.FC<DashboardNodeProps> = ({ data, id, selected
   const handleClickColumnName = useCallback((e: React.MouseEvent, exploreUrl: string) => {
     e.stopPropagation()
     window.open(exploreUrl, '_blank')
-  }, [data])
+  }, [])
 
   return (
     <DashboardNodeFrame

--- a/frontend/src/components/molecules/TableNodeFrame.tsx
+++ b/frontend/src/components/molecules/TableNodeFrame.tsx
@@ -41,7 +41,7 @@ const TableNodeFrame: React.FC<TableNodeFrameProps> = ({schema, tableName, selec
     } catch (err) {
       console.error('Failed to copy text: ', err)
     }
-  }, [tableName])
+  }, [tableName, setMessage])
 
   const handleClickXmark = useCallback((e: React.MouseEvent) => {
     e.stopPropagation()

--- a/frontend/src/components/molecules/TableNodeMoreColumns.tsx
+++ b/frontend/src/components/molecules/TableNodeMoreColumns.tsx
@@ -42,7 +42,7 @@ const TableNodeMoreColumns: React.FC<TableNodeMoreColumnsProps> = ({ schema, tab
     } finally {
       setFetching(false)
     }
-  }, [schema, tableName, nodeColumns, fetching, setFetching])
+  }, [schema, tableName, nodeColumns, fetching, setFetching, displayColumns.length])
 
   // (v)を押下したときカラム一覧を開閉する。カラム一覧を開く際にカラム情報を取得する
   const handleToggleColumns = useCallback(() => {

--- a/frontend/src/components/organisms/Header.tsx
+++ b/frontend/src/components/organisms/Header.tsx
@@ -40,11 +40,14 @@ export const Header: React.FC<HeaderProps> = ({ handleFetchData }) => {
     }
   }
 
+  // マウント時に現在の pathname で lineageMode を初期化する(以降は select の onChange で遷移)。
+  /* eslint-disable react-hooks/exhaustive-deps, react-hooks/set-state-in-effect */
   useEffect(() => {
     if (pathname !== lineageMode) {
       setLineageMode(pathname)
     }
   }, [])
+  /* eslint-enable react-hooks/exhaustive-deps, react-hooks/set-state-in-effect */
 
   return (
     <div>

--- a/frontend/src/components/organisms/Sidebar.tsx
+++ b/frontend/src/components/organisms/Sidebar.tsx
@@ -80,7 +80,7 @@ export const Sidebar = ({setNodes, setEdges, setViewIsFit, nodesPositioned, setN
     const query = new URLSearchParams({schema, source, column})
 
     router.push(`/cte?${query.toString()}`)
-  }, [nodeInternals])
+  }, [nodeInternals, router])
 
   useEffect(() => {
     try {

--- a/frontend/src/components/organisms/Sidebar.tsx
+++ b/frontend/src/components/organisms/Sidebar.tsx
@@ -80,7 +80,7 @@ export const Sidebar = ({setNodes, setEdges, setViewIsFit, nodesPositioned, setN
     const query = new URLSearchParams({schema, source, column})
 
     router.push(`/cte?${query.toString()}`)
-  }, [nodeInternals, router])
+  }, [router])
 
   useEffect(() => {
     try {
@@ -111,6 +111,9 @@ export const Sidebar = ({setNodes, setEdges, setViewIsFit, nodesPositioned, setN
     } catch (error) {
       console.log('error', error)
     }
+    // ノード寸法の測定後(flattenedNodes 更新時)と nodesPositioned 変化時にのみ再レイアウトする。
+    // edges/options/各 setter を deps に入れるとレイアウト→setNodes→再実行のループを招くため意図的に限定。
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [nodesPositioned, flattenedNodes])
 
   return (

--- a/frontend/src/components/pages/Cl.tsx
+++ b/frontend/src/components/pages/Cl.tsx
@@ -50,6 +50,8 @@ export const Cl = () => {
   const loading = useStoreZustand((state) => state.loading)
   // ロードが5秒以上続くときだけオーバーレイを表示(短時間のロードでのチラつきを防ぐ)
   const [showLoadingOverlay, setShowLoadingOverlay] = useState(false)
+  // loading の状態に応じてオーバーレイ表示を制御する(意図的な同期 setState)
+  /* eslint-disable react-hooks/set-state-in-effect */
   useEffect(() => {
     if (!loading) {
       setShowLoadingOverlay(false)
@@ -58,6 +60,7 @@ export const Cl = () => {
     const timer = setTimeout(() => setShowLoadingOverlay(true), 5000)
     return () => clearTimeout(timer)
   }, [loading])
+  /* eslint-enable react-hooks/set-state-in-effect */
   const sidebarActive = useStoreZustand((state) => state.sidebarActive)
   const options = useStoreZustand((state) => state.options)
   const setOptions = useStoreZustand((state) => state.setOptions)
@@ -114,7 +117,7 @@ export const Cl = () => {
 
     setNodesPositioned(false)
     return true
-  }, [searchParams, setNodes, setEdges, setShowColumn, setMessage])
+  }, [setNodes, setEdges, setShowColumn, setMessage])
 
   const onNodesChange = useCallback(
     (changes: NodeChange[]) =>
@@ -145,9 +148,12 @@ export const Cl = () => {
     }
   }, [clearNodePosition, setClearNodePosition])
 
+  // サイドバー開閉時にノードを再レイアウトさせる(意図的な同期 setState)
+  /* eslint-disable react-hooks/set-state-in-effect */
   useEffect(() => {
     setNodesPositioned(false)
   }, [sidebarActive])
+  /* eslint-enable react-hooks/set-state-in-effect */
 
   useEffect(() => {
     setOptions({ rankdir: 'RL' })

--- a/frontend/src/components/pages/Cl.tsx
+++ b/frontend/src/components/pages/Cl.tsx
@@ -114,7 +114,7 @@ export const Cl = () => {
 
     setNodesPositioned(false)
     return true
-  }, [searchParams])
+  }, [searchParams, setNodes, setEdges, setShowColumn, setMessage])
 
   const onNodesChange = useCallback(
     (changes: NodeChange[]) =>
@@ -143,7 +143,7 @@ export const Cl = () => {
       setClearNodePosition(false)
       setTimeout(()=>setNodesPositioned(false), 100)
     }
-  }, [clearNodePosition])
+  }, [clearNodePosition, setClearNodePosition])
 
   useEffect(() => {
     setNodesPositioned(false)
@@ -151,7 +151,7 @@ export const Cl = () => {
 
   useEffect(() => {
     setOptions({ rankdir: 'RL' })
-  }, [])
+  }, [setOptions])
 
   return (
     <div>

--- a/frontend/src/components/pages/Cte.tsx
+++ b/frontend/src/components/pages/Cte.tsx
@@ -110,48 +110,6 @@ const CteFlow = ({ nodes, edges, setNodes, setEdges, nodesPositioned, setNodesPo
   const options = useStoreZustand((state) => state.options)
   const setOptions = useStoreZustand((state) => state.setOptions)
 
-  const codeJump = useCallback((node: Node) => {
-    if (codeMirrorRef.current == null || codeMirrorRef.current.view == null) {
-      return
-    }
-    const view: EditorView = codeMirrorRef.current.view
-    const searchQuery = `${node.data.label} as (`
-    const cursorValues = searchTextCodeMirror(view, searchQuery)
-    if (!cursorValues) return
-    view?.dispatch({
-      selection: { head: cursorValues[0].from, anchor: cursorValues[0].to },
-      scrollIntoView: true,
-      effects: EditorView.scrollIntoView(cursorValues[0].from, { x: 'start', y: 'start' })
-    })
-  }, [searchParams])
-
-  const changeLayout = useCallback(() => {
-    if (nodes.length == 0 || nodesPositioned) {
-      return
-    }
-    const layouted = getLayoutedElements(nodes, edges, options)
-    setNodes([...layouted.nodes])
-    setEdges([...layouted.edges])
-
-    window.requestAnimationFrame(() => {
-      setTimeout(() => fitView(), 0)
-    })
-    setViewIsFit(true)
-    setNodesPositioned(true)
-  }, [nodesPositioned])
-
-  const onNodesChange = useCallback((changes: NodeChange[]) =>
-      setNodes((nds: Node[]) => applyNodeChanges(changes, nds))
-  , [setNodes])
-
-  const onEdgesChange = useCallback((changes: EdgeChange[]) =>
-      setEdges((eds: Edge[]) => applyEdgeChanges(changes, eds))
-  , [setEdges])
-
-  const onConnect = useCallback((connection: Connection) =>
-      setEdges((eds: Edge[]) => addEdge(connection, eds))
-  , [setEdges])
-
   const searchTextCodeMirror = useCallback((view: EditorView, searchQuery: string) => {
     const cursor = new SearchCursor(view.state.doc, searchQuery)
     const matches = []
@@ -171,6 +129,51 @@ const CteFlow = ({ nodes, edges, setNodes, setEdges, nodesPositioned, setNodesPo
     }
     return matches
   }, [])
+
+  const codeJump = useCallback((node: Node) => {
+    if (codeMirrorRef.current == null || codeMirrorRef.current.view == null) {
+      return
+    }
+    const view: EditorView = codeMirrorRef.current.view
+    const searchQuery = `${node.data.label} as (`
+    const cursorValues = searchTextCodeMirror(view, searchQuery)
+    if (!cursorValues) return
+    view?.dispatch({
+      selection: { head: cursorValues[0].from, anchor: cursorValues[0].to },
+      scrollIntoView: true,
+      effects: EditorView.scrollIntoView(cursorValues[0].from, { x: 'start', y: 'start' })
+    })
+  }, [codeMirrorRef, searchTextCodeMirror])
+
+  const changeLayout = useCallback(() => {
+    if (nodes.length == 0 || nodesPositioned) {
+      return
+    }
+    const layouted = getLayoutedElements(nodes, edges, options)
+    setNodes([...layouted.nodes])
+    setEdges([...layouted.edges])
+
+    window.requestAnimationFrame(() => {
+      setTimeout(() => fitView(), 0)
+    })
+    setViewIsFit(true)
+    setNodesPositioned(true)
+    // nodesPositioned が false になった時のみ現在の nodes/edges でレイアウトする。
+    // nodes/edges を deps に入れると setNodes→再生成→再レイアウトのループを招くため意図的に限定。
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [nodesPositioned])
+
+  const onNodesChange = useCallback((changes: NodeChange[]) =>
+      setNodes((nds: Node[]) => applyNodeChanges(changes, nds))
+  , [setNodes])
+
+  const onEdgesChange = useCallback((changes: EdgeChange[]) =>
+      setEdges((eds: Edge[]) => applyEdgeChanges(changes, eds))
+  , [setEdges])
+
+  const onConnect = useCallback((connection: Connection) =>
+      setEdges((eds: Edge[]) => addEdge(connection, eds))
+  , [setEdges])
 
   const highlightColumns = useCallback(() => {
     if (nodes.length == 0 || nodesPositioned) return
@@ -229,25 +232,33 @@ const CteFlow = ({ nodes, edges, setNodes, setEdges, nodesPositioned, setNodesPo
     codeMirrorRef.current.view.dispatch({ effects: highlightEffect.of(columnHighlightDecorationRanges as any) })
     codeMirrorRef.current.view.dispatch({ effects: highlightEffect.of(nextColumnHighlightDecorationRanges as any) })
     codeMirrorRef.current.view.dispatch({ effects: highlightEffect.of(nextTableHighlightDecorationRanges as any) })
-  }, [entireMeta, nodesPositioned, codeMirrorRef.current])
+    // entireMeta / nodesPositioned 変化時のみ再ハイライトする(CodeMirror と dagre のタイミングに依存)。
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [entireMeta, nodesPositioned])
 
   const nodeTypes = useMemo(() => ({
     cte: (props: CteNodeProps) => <CteNode {...props} />
   }), [])
 
+  // nodesPositioned 変化時にハイライトを再適用する(highlightColumns は同一トリガで安定)
+  /* eslint-disable react-hooks/exhaustive-deps */
   useEffect(() => {
     highlightColumns()
-  }, [nodesPositioned, codeMirrorRef.current])
+  }, [nodesPositioned])
+  /* eslint-enable react-hooks/exhaustive-deps */
 
+  // nodesPositioned 変化時にレイアウトし直す(changeLayout を deps に入れると再レイアウトループを招く)
+  /* eslint-disable react-hooks/exhaustive-deps */
   useEffect(() => {
     if(isFirstRender.current) return
     changeLayout()
   }, [nodesPositioned])
+  /* eslint-enable react-hooks/exhaustive-deps */
 
   useEffect(() => {
     setOptions({rankdir: 'TB'})
     isFirstRender.current = false
-  }, [])
+  }, [setOptions])
 
   return (
     <Suspense>
@@ -289,6 +300,11 @@ export const Cte = () => {
   const router = useRouter()
   const setMessage = useStoreZustand((state) => state.setMessage)
 
+  const handleClickLineageMode = useCallback(() => {
+    setMode('lineage')
+    setTimeout(()=>setNodesPositioned(false),100)
+  }, [setMode, setNodesPositioned])
+
   const handleFetchData = useCallback(async ({sources, columns}: QueryParams) => {
     setNodes([])
     setEdges([])
@@ -320,12 +336,7 @@ export const Cte = () => {
     handleClickLineageMode()
 
     return true
-  }, [router])
-
-  const handleClickLineageMode = useCallback(() => {
-    setMode('lineage')
-    setTimeout(()=>setNodesPositioned(false),100)
-  }, [setMode, setNodesPositioned])
+  }, [handleClickLineageMode, setNodes, setEdges, setMessage])
 
   const renderColumns = ({columns}: any) => {
     return (

--- a/frontend/src/components/ui/DashboardContentSelect.tsx
+++ b/frontend/src/components/ui/DashboardContentSelect.tsx
@@ -100,9 +100,11 @@ export const DashboardContentSelect: React.FC<HeaderProps> = ({handleFetchData})
       })
       router.push(`${pathname}?${query}`)
     }
-  }, [selectedDashboard])
+  }, [selectedDashboard, searchParams, pathname, router, handleFetchData, handleFetchDashboards, setLoading, setColumnModeEdges])
 
-  // 初回読み込み時の処理
+  // 初回読み込み時の処理。マウント時に1回だけ実行する(URLパラメータからの復元 or 一覧取得)。
+  // submit/handleFetchDashboards を deps に入れると毎レンダー再取得・再送信になるため意図的に空配列にしている。
+  /* eslint-disable react-hooks/exhaustive-deps, react-hooks/set-state-in-effect */
   useEffect(() => {
     if (searchParams.size) {
       submit(true)
@@ -110,11 +112,12 @@ export const DashboardContentSelect: React.FC<HeaderProps> = ({handleFetchData})
       handleFetchDashboards()
     }
   }, [])
+  /* eslint-enable react-hooks/exhaustive-deps, react-hooks/set-state-in-effect */
 
   // submitボタンのdisabled制御
   useEffect(() => {
     setIsSubmitDisabled(!selectedDashboard)
-  }, [selectedDashboard])
+  }, [selectedDashboard, setIsSubmitDisabled])
 
   // 選択されたダッシュボードの表示名を更新
   useEffect(() => {
@@ -123,9 +126,11 @@ export const DashboardContentSelect: React.FC<HeaderProps> = ({handleFetchData})
     } else {
       setHeaderSearchDisplayMessage('Select dashboard')
     }
-  }, [selectedDashboard, dashboards])
+  }, [selectedDashboard, dashboards, setHeaderSearchDisplayMessage])
 
-  // submitボタン押下時の処理
+  // submitボタン押下時の処理。submitClicked が true になった時だけ送信する。
+  // submit を deps に入れると submit の再生成で二重送信になりうるため意図的に submitClicked のみ。
+  /* eslint-disable react-hooks/exhaustive-deps, react-hooks/set-state-in-effect */
   useEffect(() => {
     if (submitClicked) {
       console.log(submitClicked)
@@ -133,6 +138,7 @@ export const DashboardContentSelect: React.FC<HeaderProps> = ({handleFetchData})
       resetSubmitClicked()
     }
   }, [submitClicked])
+  /* eslint-enable react-hooks/exhaustive-deps, react-hooks/set-state-in-effect */
 
   return (
     <div>

--- a/frontend/src/components/ui/SchemaSourceColumnSelect.tsx
+++ b/frontend/src/components/ui/SchemaSourceColumnSelect.tsx
@@ -168,13 +168,17 @@ export const SchemaSourceColumnSelect: React.FC<HeaderProps> = ({handleFetchData
       })
       router.push(`${pathname}?${query}`)
     }
-  }, [pathname, schema, selectedSources, activeSource, searchShowColumn, selectedColumnsBySource])
+  }, [pathname, schema, selectedSources, activeSource, searchShowColumn, selectedColumnsBySource,
+    searchParams, router, handleFetchData, handleFetchSchemasData, changeSchema, changeSources,
+    changeActiveSource, setLoading, setColumnModeEdges])
 
   const handleHeaderShowColumnChange = useCallback((newShowColumn: boolean) => {
     setSearchShowColumn(newShowColumn)
   }, [setSearchShowColumn])
 
-  // 初回読み込み時の処理
+  // 初回読み込み時の処理。マウント時に1回だけ実行する(URLパラメータからの復元 or 初期一覧取得)。
+  // submit/handleFetch* を deps に入れると毎レンダー再取得・再送信になるため意図的に空配列にしている。
+  /* eslint-disable react-hooks/exhaustive-deps, react-hooks/set-state-in-effect */
   useEffect(() => {
     if (searchParams.size) {
       submit(true)
@@ -184,6 +188,7 @@ export const SchemaSourceColumnSelect: React.FC<HeaderProps> = ({handleFetchData
       handleFetchColumnsData(activeSource)
     }
   }, [])
+  /* eslint-enable react-hooks/exhaustive-deps, react-hooks/set-state-in-effect */
 
   useEffect(() => {
     // 基本条件: schemaとsourceの選択が必要
@@ -207,7 +212,7 @@ export const SchemaSourceColumnSelect: React.FC<HeaderProps> = ({handleFetchData
 
     // 基本条件を満たし、かつCLモードでない場合は有効
     setIsSubmitDisabled(false)
-  }, [schema, selectedSources, activeSource, selectedColumnsBySource, searchShowColumn])
+  }, [schema, selectedSources, activeSource, selectedColumnsBySource, searchShowColumn, isCl, setIsSubmitDisabled])
 
   // 選択されたスキーマ、ソース、カラムの表示名を更新
   useEffect(() => {
@@ -220,9 +225,11 @@ export const SchemaSourceColumnSelect: React.FC<HeaderProps> = ({handleFetchData
     } else {
       setHeaderSearchDisplayMessage('Select search model')
     }
-  }, [schema, activeSource, currentSelectedColumns])
+  }, [schema, activeSource, currentSelectedColumns, setHeaderSearchDisplayMessage])
 
-  // submitボタン押下時の処理
+  // submitボタン押下時の処理。submitClicked が true になった時だけ送信する。
+  // submit を deps に入れると submit の再生成で二重送信になりうるため意図的に submitClicked のみ。
+  /* eslint-disable react-hooks/exhaustive-deps, react-hooks/set-state-in-effect */
   useEffect(() => {
     if (submitClicked) {
       console.log(submitClicked)
@@ -230,6 +237,7 @@ export const SchemaSourceColumnSelect: React.FC<HeaderProps> = ({handleFetchData
       resetSubmitClicked()
     }
   }, [submitClicked])
+  /* eslint-enable react-hooks/exhaustive-deps, react-hooks/set-state-in-effect */
 
   return (
     <div>

--- a/frontend/src/components/ui/SearchDialog.tsx
+++ b/frontend/src/components/ui/SearchDialog.tsx
@@ -25,13 +25,16 @@ export const SearchDialog: React.FC<HeaderProps> = ({handleFetchData}) => {
     setSourceMode(mode)
   }
 
+  // マウント時のみ: 初期URLに dashboardId があれば looker モードで開始する。
+  /* eslint-disable react-hooks/exhaustive-deps */
   useEffect(() => {
     if (searchParams.get('dashboardId')) setSourceMode('looker')
   }, [])
+  /* eslint-enable react-hooks/exhaustive-deps */
 
   useEffect(() => {
     if (!isCl) setSourceMode('dbt')
-  }, [isCl])
+  }, [isCl, setSourceMode])
 
   useEffect(() => {
     function handleClickOutside(event: MouseEvent) {

--- a/frontend/src/components/ui/ToggleButtons.tsx
+++ b/frontend/src/components/ui/ToggleButtons.tsx
@@ -78,7 +78,7 @@ const ToggleButtons = () => {
 
     }
     setClearNodePosition(true)
-  }, [getEdges, setEdges, setShowColumn, setClearNodePosition, columnModeEdges])
+  }, [getEdges, setEdges, setShowColumn, setClearNodePosition, columnModeEdges, setColumnModeEdges, setRightMaxDepth])
 
   const copyToClipboard = useCallback(async() => {
     const flowElement = document.querySelector('.react-flow__viewport') as HTMLElement
@@ -100,7 +100,7 @@ const ToggleButtons = () => {
         setTimeout(() => setMessage(null, null), 3000) // Clear message after 3 seconds
       }
     }
-  }, [])
+  }, [fitView, setMessage])
 
   return (
     <div className="flex flex-col space-y-4">

--- a/frontend/src/components/ui/ToggleButtons.tsx
+++ b/frontend/src/components/ui/ToggleButtons.tsx
@@ -22,10 +22,12 @@ const ToggleButtons = () => {
     { id: 'column', icon: Columns3, label: 'Column' },
   ]
 
-  // showColumnが変更されたときにactiveButtonを変更する
+  // showColumnが変更されたときにactiveButtonを変更する(showColumn から導出する同期 setState)
+  /* eslint-disable react-hooks/set-state-in-effect */
   useEffect(() => {
     setActiveButton(showColumn ? 'column' : 'table')
   }, [showColumn])
+  /* eslint-enable react-hooks/set-state-in-effect */
 
   // ボタンが押されたときの処理
   const handleToggleButton = useCallback((buttonId: string) => {

--- a/frontend/src/hooks/useEventNodeOperations.ts
+++ b/frontend/src/hooks/useEventNodeOperations.ts
@@ -92,7 +92,7 @@ export const useEventNodeOperations = (id: string) => {
     setEdges(mergedEdges)
 
     setClearNodePosition(true)
-  }, [getNodes, getEdges, showColumn, rightMaxDepth])
+  }, [getNodes, getEdges, showColumn, rightMaxDepth, mergeNodes, mergeEdges, setNodes, setEdges, setClearNodePosition, setLoading])
 
   // シングルリネージしてノードを追加する
   const addSingleLineage = useCallback(async (source: string, column: string) => {
@@ -127,7 +127,7 @@ export const useEventNodeOperations = (id: string) => {
     // updateNodeInternals(id)
 
     setClearNodePosition(true)
-  }, [getNodes, getEdges, showColumn, updateNodeInternals, leftMaxDepth])
+  }, [getNodes, getEdges, showColumn, updateNodeInternals, leftMaxDepth, mergeNodes, mergeEdges, setNodes, setEdges, setClearNodePosition, setLoading])
 
   // ノードを非表示にする
   const hideNode = useCallback(() => {
@@ -140,7 +140,7 @@ export const useEventNodeOperations = (id: string) => {
     ))
 
     setClearNodePosition(true)
-  }, [id, setNodes, setEdges])
+  }, [id, setNodes, setEdges, setClearNodePosition])
 
   // targetに複数のエッジを持つノードを取得
   const identifyNodesWithMultipleConnections = useCallback((edges: Edge[]): string[] => {
@@ -168,18 +168,24 @@ export const useEventNodeOperations = (id: string) => {
 
   // 子孫ノードを取得する
   const getDescendantNodes = useCallback((nodeId: string, edges: Edge[]): string[] => {
-    const childEdges = edges.filter(edge => edge.source === nodeId)
-    const childNodeIds = childEdges.map(edge => edge.target)
-    const nodesWithMultipleConnections =  identifyNodesWithMultipleConnections(edges)
+    // edges は再帰を通じて不変なので、複数接続ノードの判定は一度だけ計算する
+    const nodesWithMultipleConnections = identifyNodesWithMultipleConnections(edges)
 
-    const newChildNodeIds = childNodeIds.filter(childId => {
-      // 複数のエッジを持つノードはその子孫ノードを取得しない
-      return (!nodesWithMultipleConnections.includes(childId))
-    })
+    const walk = (id: string): string[] => {
+      const childEdges = edges.filter(edge => edge.source === id)
+      const childNodeIds = childEdges.map(edge => edge.target)
 
-    const descendantNodeIds = newChildNodeIds.flatMap(childId => getDescendantNodes(childId, edges))
-    return [...newChildNodeIds, ...descendantNodeIds]
-  }, [getEdges])
+      const newChildNodeIds = childNodeIds.filter(childId => {
+        // 複数のエッジを持つノードはその子孫ノードを取得しない
+        return (!nodesWithMultipleConnections.includes(childId))
+      })
+
+      const descendantNodeIds = newChildNodeIds.flatMap(childId => walk(childId))
+      return [...newChildNodeIds, ...descendantNodeIds]
+    }
+
+    return walk(nodeId)
+  }, [identifyNodesWithMultipleConnections])
 
   // 特定のカラムと関連するエッジを削除
   const hideColumnAndRelatedEdges = useCallback((nodeId: string, columnId: string) => {
@@ -249,7 +255,7 @@ export const useEventNodeOperations = (id: string) => {
     })
 
     setClearNodePosition(true)
-  }, [showColumn, setNodes, setEdges, getDescendantNodes, getNodes, getEdges])
+  }, [showColumn, setNodes, setEdges, getDescendantNodes, getNodes, getEdges, setClearNodePosition])
 
   // テーブルと関連するエッジを削除
   const hideTableAndRelatedEdges = useCallback((nodeId: string) => {
@@ -264,7 +270,7 @@ export const useEventNodeOperations = (id: string) => {
       }
     )
     setClearNodePosition(true)
-  }, [getDescendantNodes, getNodes, getEdges])
+  }, [getDescendantNodes, getNodes, getEdges, id, setNodes, setEdges, setClearNodePosition])
 
   return {
     addReverseLineage,

--- a/frontend/src/hooks/useEventNodeOperations.ts
+++ b/frontend/src/hooks/useEventNodeOperations.ts
@@ -127,7 +127,7 @@ export const useEventNodeOperations = (id: string) => {
     // updateNodeInternals(id)
 
     setClearNodePosition(true)
-  }, [getNodes, getEdges, showColumn, updateNodeInternals, leftMaxDepth, mergeNodes, mergeEdges, setNodes, setEdges, setClearNodePosition, setLoading])
+  }, [getNodes, getEdges, showColumn, leftMaxDepth, mergeNodes, mergeEdges, setNodes, setEdges, setClearNodePosition, setLoading])
 
   // ノードを非表示にする
   const hideNode = useCallback(() => {
@@ -255,7 +255,7 @@ export const useEventNodeOperations = (id: string) => {
     })
 
     setClearNodePosition(true)
-  }, [showColumn, setNodes, setEdges, getDescendantNodes, getNodes, getEdges, setClearNodePosition])
+  }, [setNodes, setEdges, getDescendantNodes, getNodes, getEdges, setClearNodePosition])
 
   // テーブルと関連するエッジを削除
   const hideTableAndRelatedEdges = useCallback((nodeId: string) => {


### PR DESCRIPTION
`react-hooks` の lint 警告 **50 件 → 0 件**(0 errors / 0 warnings)。bisect 可能にするため **2 コミット**に分割。

## コミット1: Tier 1(挙動完全不変)— 50→39
安定参照(useState/useReactFlow setter・zustand action・next router・fitView)を deps に追加、不要 dep 削除、自己再帰の内部ヘルパー化のみ。effect/callback の identity は変えていないため挙動は不変。
- 主に `useEventNodeOperations` の add/hide 系、`Cl`/`ToggleButtons`/`Sidebar`/`TableNodeFrame`/`DashboardNode`
- `getDescendantNodes` の `react-hooks/immutability` エラー(自己参照)を内部 `walk()` で解消(同一アルゴリズム)

## コミット2: Tier 2(要判断)— 39→0
deps の一律補完は再フェッチ/無限ループを招くため、各サイトで**本当に直す**か**意図を明記した eslint-disable** かを選択。

**実際に修正(挙動不変):**
- 2 つの Select の `submit` の deps を完全化(`submit` はどの fetch effect の dep でもないためループしない)
- isSubmitDisabled / 表示名 / isCl 系 effect に安定 setter を追加
- `Cte`: `searchText*`/`handleClickLineageMode` を使用箇所より前へ移動(used-before-declared を解消)、highlight effect の `codeMirrorRef.current` アンチパターン除去
- Tier1 後に顕在化した不要 dep を削除

**意図的な eslint-disable(直すと挙動が変わる/ループする):**
- マウント時のみ/submit 時のみの effect(各 Select・SearchDialog・Header)— submit/fetch 関数や searchParams を deps に入れると毎レンダー再取得・二重送信
- derived/sync state の `set-state-in-effect`(Cl のオーバーレイ・再レイアウト、ToggleButtons の activeButton、Header の lineageMode 初期化)
- dagre レイアウト/ハイライト effect(Sidebar・Cte)— nodes/edges/options を deps に入れると再レイアウトループ

## 検証(next 16 dev 実機)
- `Maximum update depth exceeded` **無し**、コンソール **0 errors**
- 新規 `/cl` ロード(URL→submit(true) 経路)、検索ダイアログの状態復元、ノード hide / (+) 展開 / カラムトグル、`/cte` + Description タブ(markdown)すべて従来どおり
- `npm run lint` 0/0、build + 静的エクスポート クリーン

> 単独 PR(develop ベース)。意図的 disable はすべて理由コメント付き。

🤖 Generated with [Claude Code](https://claude.com/claude-code)