### PR TITLE
fix(frontend): restore Tailwind v4 opacity utilities missed by the codemod

### DIFF
--- a/frontend/src/components/pages/Cte.tsx
+++ b/frontend/src/components/pages/Cte.tsx
@@ -369,7 +369,7 @@ export const Cte = () => {
           <h4 className="h-[32px] px-1 text-2xl font-bold flex items-center">
             <span className="select-text truncate" title={tableName}>{tableName}</span>
             <span
-              className={`ms-2 text-sm font-semibold text-gray-500 dark:text-gray-400 select-text ${getColorClassForMaterialized(materialized)} bg-opacity-50 rounded-sm px-2 py-1`}>
+              className={`ms-2 text-sm font-semibold text-gray-500 dark:text-gray-400 select-text ${getColorClassForMaterialized(materialized)} rounded-sm px-2 py-1`}>
               {materialized}
             </span>
           </h4>

--- a/frontend/src/components/ui/SearchDialog.tsx
+++ b/frontend/src/components/ui/SearchDialog.tsx
@@ -64,7 +64,7 @@ export const SearchDialog: React.FC<HeaderProps> = ({handleFetchData}) => {
       </button>
 
       <div
-        className={`origin-top-left absolute left-0 mt-2 w-[900px] rounded-md shadow-lg bg-white ring-1 ring-black ring-opacity-5 focus:outline-hidden z-50 ${
+        className={`origin-top-left absolute left-0 mt-2 w-[900px] rounded-md shadow-lg bg-white ring-1 ring-black/5 focus:outline-hidden z-50 ${
           isDialogOpen ? 'block' : 'hidden'
         }`}
       >


### PR DESCRIPTION
Tailwind v3→v4 移行(#13/#14)時に、`@tailwindcss/upgrade` codemod が**テンプレートリテラル内の className を変換しきれず**、v4 で廃止された不透明度ユーティリティが 2 箇所残っていた。v4 ではこれらは黙って無効化されるため、見た目が変わっていた。

## 修正
- **SearchDialog のドロップダウン**(報告された不具合): `ring-1 ring-black ring-opacity-5` が、v4 では `ring-opacity-5` が無効化され **不透明度 100% の黒い 1px 罫線**として描画されていた(本来は 5% でほぼ見えず、影だけのウィンドウ)。v4 のスラッシュ記法 `ring-1 ring-black/5` に修正(生成 CSS: `--tw-ring-color:#0000000d` = 黒 5%)。
- **Cte の materialized バッジ**: 死んだ `bg-opacity-50` トークンを除去(v4 で無効。bg 色は runtime ヘルパー由来で `/50` を静的に付けられないため、ヘルパーの色をそのまま使用)。

その他の v3 廃止/改名ユーティリティ(`*-opacity-*`・`flex-grow/shrink`・`overflow-ellipsis`)も全体を掃き出し、残存なしを確認。

## 検証
- build + lint クリーン
- `ring-black/5` が `#0000000d`(黒 5%)で生成されることを出力 CSS で確認
- 注: Playwright MCP が本セッションで切断中のため、実機ではなく生成 CSS で検証

🤖 Generated with [Claude Code](https://claude.com/claude-code)