### PR TITLE
chore(docker): bump node builder to 24 LTS and modernize Dockerfile syntax

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,15 @@
-FROM node:23 as node-builder
+FROM node:24 AS node-builder
 WORKDIR /frontend
 
 ARG NEXT_PUBLIC_USE_LOOKER
-ENV NEXT_PUBLIC_USE_LOOKER $NEXT_PUBLIC_USE_LOOKER
+ENV NEXT_PUBLIC_USE_LOOKER=$NEXT_PUBLIC_USE_LOOKER
 COPY frontend/package-lock.json frontend/package.json ./
 RUN npm ci
 COPY frontend .
-ENV NODE_ENV production
+ENV NODE_ENV=production
 RUN npm run build
 
-FROM python:3.12 as python-builder
+FROM python:3.12 AS python-builder
 WORKDIR /app
 
 COPY ./requirements.txt .


### PR DESCRIPTION
## 概要
公開ワークフロー(`just deploy-aws`)で使う `Dockerfile` のビルダーNodeを更新し、BuildKit警告も解消します。

## 変更点
- **`node:23` → `node:24`**: Node 23 は奇数=非LTSで既にEOL。現行LTSの 24 に更新（Next 16 / React 19 と整合）。
- **`FROM ... as` → `AS`** ×2: BuildKit の `FromAsCasing` 警告を解消。
- **`ENV key value` → `ENV key=value`** ×2: `LegacyKeyValueFormat` 警告を解消。

## 検証
- `docker build --platform linux/x86_64` がフル成功（`npm ci` / `next build` / イメージ生成すべて通過）。
- 起動したコンテナが `GET /` → **200**（フロント配信）、`GET /api/v1/schemas` → **200**（API + manifest/catalog 読込）を返すことを確認。
- 隔離環境での `npm ci`（linux/amd64・mac 両方）で `package-lock.json` の整合も確認済み（lockに変更は不要だった）。

## 補足
- `package-lock.json` はコミット済みのものが完全で正しく、本PRに含めていません。
- `target/` や `dbt_project.yml` は gitignore 対象（ビルドはローカルに存在する前提）で、本リポジトリの汎用ツール方針どおりです。

🤖 Generated with [Claude Code](https://claude.com/claude-code)