### PR TITLE
chore(docker): add .dockerignore to slim build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,18 @@
+# Node / frontend build artifacts (イメージ内で npm ci → npm run build するため不要)
+**/node_modules/
+frontend/.next/
+frontend/out/
+
+# Python build/cache
+**/__pycache__/
+*.pyc
+.venv/
+venv/
+dist/
+*.egg-info/
+
+# VCS / IDE / OS / secrets
+.git/
+.idea/
+.DS_Store
+.envrc


### PR DESCRIPTION
## 概要
`.dockerignore` が無く、`docker build`(`just deploy-aws`) のたびにホストの `frontend/node_modules`(645M) や `.next`(695M) までビルドコンテキストに送られていたため、`.dockerignore` を追加します。

## 背景
`Dockerfile` は node-builder ステージ内で `npm ci` → `npm run build` してフロントを自前ビルドするので、ホスト側の `node_modules`/`out`/`.next` は不要。しかし `.dockerignore` が無いため `COPY frontend .` がそれらを丸ごと取り込んでいた。
- コンテキスト肥大でビルドが遅い
- ホスト(mac)の `node_modules` をコンテナへ持ち込み、直前の `npm ci`(linux) 結果にマージしていた（linux固有バイナリが上書きされず残るため"たまたま"通る綱渡り状態）

## 変更
`node_modules` / `.next` / `out`、Python のキャッシュ・ビルド成果物、`.git`/`.idea`/`.envrc` 等を除外。

## 検証
`docker build --platform linux/x86_64` で確認:
- **コンテキスト転送: ~593MB → ~50kB**
- ビルドはフル成功（`✓ Compiled successfully` → イメージ生成、`npm ci` レイヤはキャッシュ利用）
- ホスト node_modules を持ち込まなくなり、コンテナ内 linux node_modules でクリーンにビルド

🤖 Generated with [Claude Code](https://claude.com/claude-code)