### PR TITLE
feat(login): style the Google OAuth login page

### DIFF
--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -1,12 +1,26 @@
+import {FcGoogle} from 'react-icons/fc'
 
 export default function Login() {
   return (
-    <div>
-      <a href={"/oauth"}>
-        <button>
-          Login to Google
-        </button>
-      </a>
-    </div>
+    <main className="min-h-screen flex items-center justify-center bg-gradient-to-br from-slate-50 to-blue-50 px-4">
+      <div className="w-full max-w-sm rounded-2xl border bg-white p-8 shadow-sm text-center">
+        <h1 className="text-2xl font-semibold text-gray-900">
+          dbt column lineage
+        </h1>
+        <p className="mt-2 text-sm text-gray-500">
+          Sign in to visualize your column-level lineage
+        </p>
+
+        <a href="/oauth" className="mt-8 block">
+          <button
+            type="button"
+            className="w-full flex items-center justify-center gap-3 rounded-lg border border-gray-300 bg-white px-4 py-2.5 text-sm font-medium text-gray-700 shadow-sm transition-colors duration-200 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-blue-400 focus:ring-offset-2"
+          >
+            <FcGoogle className="h-5 w-5" />
+            <span>Sign in with Google</span>
+          </button>
+        </a>
+      </div>
+    </main>
   )
 }


### PR DESCRIPTION
## 概要
無装飾だった `/login`(Google OAuth ログイン画面)を整えました。

**Before**: 白背景に裸の `<button>Login to Google</button>`
**After**: 中央寄せのカード(角丸・枠線・薄シャドウ・淡いグラデ背景)+ 見出し「dbt column lineage」+ サブテキスト + Google標準サインインボタン(`FcGoogle` アイコン、白地、ホバー/フォーカスリング)

## 補足
- 既存のTailwind規約(白サーフェス / blue・gray系 / `rounded`)に準拠
- 新規依存なし(`react-icons` は既存)
- `npm run lint`(0 warnings)/ `npm run build`(静的エクスポート)ともクリーン

🤖 Generated with [Claude Code](https://claude.com/claude-code)