### PR TITLE
feat(lineage): ノードメニューに「Open in dbt docs」リンクを追加

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,7 +33,9 @@ The frontend reaches the backend via `process.env.NEXT_PUBLIC_API_HOSTNAME` (emp
 - `SQLGLOT_DIALECT` — sqlglot dialect for parsing compiled SQL (default `snowflake`). Must match the dbt warehouse.
 - A dbt project with `target/manifest.json` and `target/catalog.json` (run `dbt docs generate`). The backend locates it via `DBT_PROJECT_DIR`, else auto-detects (`dbt_project.yml` in cwd / common locations — see `utils.find_dbt_project`).
 
-Other env flags (see `constants.py`): `USE_OAUTH`, `DEBUG_MODE`, `NEXT_PUBLIC_USE_LOOKER`, `GOOGLE_CLIENT_ID`/`GOOGLE_CLIENT_SECRET`.
+Other env flags (see `constants.py`): `USE_OAUTH`, `DEBUG_MODE`, `NEXT_PUBLIC_USE_LOOKER`, `GOOGLE_CLIENT_ID`/`GOOGLE_CLIENT_SECRET`, `DBT_DOCS_BASE_URL`.
+
+- `DBT_DOCS_BASE_URL` — base URL of a dbt-docs site (e.g. `https://docs.example.com/dbt/latest`). When set, each table node's menu gains an **"Open in dbt docs"** item linking to `{base}/#!/{resource_type}/{unique_id}`. The full URL is built **server-side** in `lineage.py` (`__dbt_docs_url`, read from the manifest node — not reconstructed) and attached as `node.data.docsUrl`, so this is a true **runtime** env var (unlike `NEXT_PUBLIC_*`, which bake into the static frontend at build time). Unset → no `docsUrl` → the menu item is hidden.
 
 > ⚠️ `.envrc` is gitignored but currently contains **real secrets** (Google OAuth + Looker SDK credentials). Do not commit it or echo its contents into other files; treat those values as compromised if exposed.
 

--- a/frontend/src/components/molecules/TableNode.tsx
+++ b/frontend/src/components/molecules/TableNode.tsx
@@ -16,6 +16,7 @@ type TableNodeDataType = {
   columns: string[]
   first: boolean
   last: boolean
+  docsUrl?: string | null
 }
 
 export type TableNodeType = Node<TableNodeDataType, 'tableNode'>
@@ -70,6 +71,7 @@ export const TableNode: React.FC<TableNodeProps> = ({ data, id, selected }) => {
       hideNode={hideNode}
       isClickableTableName={true}
       materialized={data.materialized}
+      docsUrl={data.docsUrl}
       content={
         <>
           {(firstNodeTable != data.name) && (
@@ -108,6 +110,7 @@ export const TableNode: React.FC<TableNodeProps> = ({ data, id, selected }) => {
       hideNode={hideNode}
       isClickableTableName={false}
       materialized={data.materialized}
+      docsUrl={data.docsUrl}
       content={
         <>
           {/* table => column 切替時に残るハンドル */}

--- a/frontend/src/components/molecules/TableNodeFrame.tsx
+++ b/frontend/src/components/molecules/TableNodeFrame.tsx
@@ -2,7 +2,7 @@
 import React, { memo, useCallback, useMemo, useState } from 'react'
 import { faCopy } from '@fortawesome/free-regular-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { faEllipsisV, faTimes } from '@fortawesome/free-solid-svg-icons'
+import { faEllipsisV, faTimes, faUpRightFromSquare } from '@fortawesome/free-solid-svg-icons'
 import { useSearchParams } from 'next/navigation'
 import { useStore as useStoreZustand } from '@/store/zustand'
 import { getColorClassForMaterialized } from '@/lib/utils'
@@ -15,9 +15,10 @@ interface TableNodeFrameProps {
   isClickableTableName: boolean
   content: React.ReactNode
   hideNode: () => void
+  docsUrl?: string | null
 }
 
-const TableNodeFrame: React.FC<TableNodeFrameProps> = ({schema, tableName, selected, materialized, isClickableTableName, content, hideNode}) => {
+const TableNodeFrame: React.FC<TableNodeFrameProps> = ({schema, tableName, selected, materialized, isClickableTableName, content, hideNode, docsUrl}) => {
   const setMessage = useStoreZustand((state) => state.setMessage)
   const searchParams = useSearchParams()
   const [showMenu, setShowMenu] = useState(false)
@@ -42,6 +43,14 @@ const TableNodeFrame: React.FC<TableNodeFrameProps> = ({schema, tableName, selec
       console.error('Failed to copy text: ', err)
     }
   }, [tableName, setMessage])
+
+  // dbt docs の該当ノードページを別タブで開く(DBT_DOCS_BASE_URL 設定時のみ docsUrl が来る)
+  const handleClickOpenDocs = useCallback((e: React.MouseEvent) => {
+    e.stopPropagation()
+    if (docsUrl) {
+      window.open(docsUrl, '_blank', 'noopener,noreferrer')
+    }
+  }, [docsUrl])
 
   const handleClickXmark = useCallback((e: React.MouseEvent) => {
     e.stopPropagation()
@@ -99,6 +108,16 @@ const TableNodeFrame: React.FC<TableNodeFrameProps> = ({schema, tableName, selec
                     <FontAwesomeIcon icon={faCopy} className="mr-2" />
                     Copy table name
                   </button>
+                  {docsUrl && (
+                    <button
+                      onClick={handleClickOpenDocs}
+                      className="block w-full text-left px-4 py-2 text-sm text-gray-700 hover:bg-gray-100"
+                      title="Open in dbt docs"
+                    >
+                      <FontAwesomeIcon icon={faUpRightFromSquare} className="mr-2" />
+                      Open in dbt docs
+                    </button>
+                  )}
                 </div>
               </div>
             )}

--- a/src/dbt_column_lineage/constants.py
+++ b/src/dbt_column_lineage/constants.py
@@ -7,3 +7,9 @@ USE_LOOKER = os.getenv('NEXT_PUBLIC_USE_LOOKER', 'false').lower() == 'true'
 GOOGLE_CLIENT_ID = os.getenv('GOOGLE_CLIENT_ID')
 GOOGLE_CLIENT_SECRET = os.getenv('GOOGLE_CLIENT_SECRET')
 SQLGLOT_DIALECT=os.getenv('SQLGLOT_DIALECT', 'snowflake')
+
+# dbt docs (dbt-docs SPA) のベースURL。設定すると各テーブルノードのメニューに
+# 「Open in dbt docs」が出て {base}/#!/{resource_type}/{unique_id} に遷移する。
+# 汎用ツールなので固定せず、環境ごとに実行時に指定する。未設定ならメニューは出ない。
+# 例: https://docs.example.com/dbt/latest
+DBT_DOCS_BASE_URL = os.getenv('DBT_DOCS_BASE_URL')

--- a/src/dbt_column_lineage/lineage.py
+++ b/src/dbt_column_lineage/lineage.py
@@ -8,7 +8,7 @@ from sqlglot.errors import SqlglotError
 from sqlglot.lineage import lineage
 from sqlglot.optimizer import build_scope, Scope, qualify
 
-from dbt_column_lineage.constants import SQLGLOT_DIALECT, USE_LOOKER
+from dbt_column_lineage.constants import SQLGLOT_DIALECT, USE_LOOKER, DBT_DOCS_BASE_URL
 from dbt_column_lineage.looker import Looker
 from dbt_column_lineage.utils import get_dbt_project_dir
 
@@ -213,6 +213,20 @@ class DbtSqlglot:
             })
         return res
 
+    def __dbt_docs_url(self, dbt_node: dict) -> t.Optional[str]:
+        """dbt-docs SPA の該当ノードURLを返す。DBT_DOCS_BASE_URL 未設定、または
+        dbt ノードが解決できない(exposure/source/未知名 → {})場合は None。
+        unique_id は manifest が持つ正規値をそのまま使う(再構築しない)。
+        例: {base}/#!/model/model.proj.my_model"""
+        if not DBT_DOCS_BASE_URL or not dbt_node:
+            return None
+        unique_id = dbt_node.get('unique_id')
+        resource_type = dbt_node.get('resource_type')
+        if not unique_id or not resource_type:
+            return None
+        base = DBT_DOCS_BASE_URL.rstrip('/')
+        return f'{base}/#!/{resource_type}/{unique_id}'
+
     def __add_node(self, next_source, dbt_schema, filtered_columns, dbt_materialized, depth):
         node_columns = list(filtered_columns)
         node_id = self.__str_to_base_10_int_str(next_source)
@@ -241,6 +255,7 @@ class DbtSqlglot:
                 'materialized' : dbt_materialized,
                 'schema': dbt_schema, 'columns': node_columns,
                 'first': False, 'last': False,
+                'docsUrl': self.__dbt_docs_url(self.__get_dbt_node(next_source)),
             },
             'position': {'x': 0,'y': 0},
             # 'max_len': max_len, 'depth': depth,
@@ -569,7 +584,8 @@ class DbtSqlglot:
                     'columns': [],
                     'schema': ref_schema,
                     'materialized': ref_materialized,
-                    'first': False, 'last': False
+                    'first': False, 'last': False,
+                    'docsUrl': self.__dbt_docs_url(ref_dbt_node),
                 },
                 'position': {'x': 0,'y': 0},
                 'type': 'tableNode'

--- a/test/unit/test_dbt_docs_url.py
+++ b/test/unit/test_dbt_docs_url.py
@@ -1,0 +1,59 @@
+"""Tests for the dbt-docs deep link attached to table nodes.
+
+`DbtSqlglot` attaches `data.docsUrl` to each table node so the frontend menu can
+offer "Open in dbt docs". The URL is `{DBT_DOCS_BASE_URL}/#!/{resource_type}/{unique_id}`
+built from the manifest node's own fields (not reconstructed). When the env var
+is unset the value is None and the frontend hides the menu item.
+
+`DBT_DOCS_BASE_URL` is read into lineage.py at import time, so we monkeypatch the
+module-level name rather than os.environ.
+"""
+import dbt_column_lineage.lineage as lineage_mod
+
+
+def _docs_url(dbt, name):
+    node = dbt._DbtSqlglot__get_dbt_node(name)
+    return dbt._DbtSqlglot__dbt_docs_url(node)
+
+
+def test_docs_url_none_when_base_unset(dbt, monkeypatch):
+    monkeypatch.setattr(lineage_mod, "DBT_DOCS_BASE_URL", None)
+    assert _docs_url(dbt, "base_model") is None
+
+
+def test_docs_url_uses_manifest_unique_id_and_resource_type(dbt, monkeypatch):
+    monkeypatch.setattr(lineage_mod, "DBT_DOCS_BASE_URL", "https://docs.example.com/dbt/latest")
+    assert _docs_url(dbt, "base_model") == (
+        "https://docs.example.com/dbt/latest/#!/model/model.test_proj.base_model"
+    )
+
+
+def test_docs_url_strips_trailing_slash(dbt, monkeypatch):
+    # ベースURL末尾の / を1つ剥がして // にならないようにする
+    monkeypatch.setattr(lineage_mod, "DBT_DOCS_BASE_URL", "https://docs.example.com/dbt/latest/")
+    assert _docs_url(dbt, "child_model") == (
+        "https://docs.example.com/dbt/latest/#!/model/model.test_proj.child_model"
+    )
+
+
+def test_docs_url_none_for_non_dbt_object(dbt, monkeypatch):
+    # exposure/source/未知名 は __get_dbt_node が {} を返す → docsUrl なし
+    monkeypatch.setattr(lineage_mod, "DBT_DOCS_BASE_URL", "https://docs.example.com/dbt/latest")
+    assert _docs_url(dbt, "some_exposure") is None
+    assert _docs_url(dbt, "does_not_exist") is None
+
+
+def test_column_lineage_nodes_carry_docs_url(dbt, monkeypatch):
+    monkeypatch.setattr(lineage_mod, "DBT_DOCS_BASE_URL", "https://docs.example.com/dbt/latest")
+    dbt.column_lineage("plain_model", "ID", False)
+    urls = {n["data"]["name"]: n["data"].get("docsUrl") for n in dbt.ret_edges_nodes()["nodes"]}
+    assert urls["plain_model"] == "https://docs.example.com/dbt/latest/#!/model/model.test_proj.plain_model"
+    assert urls["base_model"] == "https://docs.example.com/dbt/latest/#!/model/model.test_proj.base_model"
+
+
+def test_table_lineage_nodes_carry_docs_url(dbt, monkeypatch):
+    monkeypatch.setattr(lineage_mod, "DBT_DOCS_BASE_URL", "https://docs.example.com/dbt/latest")
+    dbt.table_lineage("base_model", True)
+    urls = {n["data"]["name"]: n["data"].get("docsUrl") for n in dbt.ret_edges_nodes()["nodes"]}
+    assert urls["base_model"].endswith("/#!/model/model.test_proj.base_model")
+    assert urls["child_model"].endswith("/#!/model/model.test_proj.child_model")


### PR DESCRIPTION
## 概要
テーブルノードのメニュー(現状「Copy table name」のみ)に **「Open in dbt docs」** を追加。`DBT_DOCS_BASE_URL` 設定時のみ表示され、そのモデルの dbt-docs ページを別タブで開く。

例: `https://docs.example.com/dbt/latest/#!/model/model.data_cuisine_dbt.int_kosms_...`

## 設計
- URL は **サーバ側**(`lineage.py` の `__dbt_docs_url`)で `{base}/#!/{resource_type}/{unique_id}` を組み立て、ノードの `data.docsUrl` に載せる。`unique_id`/`resource_type` は **manifest のノードからそのまま取得**(フロントで再構築しない)。
- `DBT_DOCS_BASE_URL` は **ランタイム env**(`NEXT_PUBLIC_*` のようなビルド時焼き込みではない)。汎用ツールなので固定せず環境ごとに指定でき、`pip install` した wheel でも `dbt-column-lineage run` 前に設定すれば効く。
- 未設定 → `docsUrl` 無し → メニュー項目は非表示。exposure/source/Looker など dbt ノードに解決できないものはリンク無し。
- ベースURL末尾の `/` は1つ剥がして `//` を防止。リンクは `_blank` + `noopener,noreferrer`。

## テスト
`test/unit/test_dbt_docs_url.py` を追加(env未設定→None / 末尾スラッシュ除去 / 非dbtオブジェクト→None / column・table 両リネージのノードがURLを持つ)。**ユニット計27件 pass**、フロント `lint` 0 warnings・`build`(静的エクスポート)クリーン。

## 補足
`constants.py`/`CLAUDE.md` に `DBT_DOCS_BASE_URL` を追記。

🤖 Generated with [Claude Code](https://claude.com/claude-code)