### PR TITLE
feat(server): multi-worker readiness + lineage depth cap (App Runner 高負荷耐性)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,9 +33,12 @@ The frontend reaches the backend via `process.env.NEXT_PUBLIC_API_HOSTNAME` (emp
 - `SQLGLOT_DIALECT` — sqlglot dialect for parsing compiled SQL (default `snowflake`). Must match the dbt warehouse.
 - A dbt project with `target/manifest.json` and `target/catalog.json` (run `dbt docs generate`). The backend locates it via `DBT_PROJECT_DIR`, else auto-detects (`dbt_project.yml` in cwd / common locations — see `utils.find_dbt_project`).
 
-Other env flags (see `constants.py`): `USE_OAUTH`, `DEBUG_MODE`, `NEXT_PUBLIC_USE_LOOKER`, `GOOGLE_CLIENT_ID`/`GOOGLE_CLIENT_SECRET`, `DBT_DOCS_BASE_URL`.
+Other env flags (see `constants.py`): `USE_OAUTH`, `DEBUG_MODE`, `NEXT_PUBLIC_USE_LOOKER`, `GOOGLE_CLIENT_ID`/`GOOGLE_CLIENT_SECRET`, `DBT_DOCS_BASE_URL`, `SESSION_SECRET`, `MAX_LINEAGE_DEPTH`.
 
 - `DBT_DOCS_BASE_URL` — base URL of a dbt-docs site (e.g. `https://docs.example.com/dbt/latest`). When set, each table node's menu gains an **"Open in dbt docs"** item linking to `{base}/#!/{resource_type}/{unique_id}`. The full URL is built **server-side** in `lineage.py` (`__dbt_docs_url`, read from the manifest node — not reconstructed) and attached as `node.data.docsUrl`, so this is a true **runtime** env var (unlike `NEXT_PUBLIC_*`, which bake into the static frontend at build time). Unset → no `docsUrl` → the menu item is hidden.
+
+- `SESSION_SECRET` — fixed signing key for the session cookie. Required when running more than one process (`uvicorn --workers`, or App Runner scaling out to >1 instance) **and** `USE_OAUTH=true`, otherwise each process generates a random key and signed-cookie sessions break across processes (login fails / API 401s). Unset → per-process random key (single-process default). The Docker image runs `uvicorn --workers 2`, so set this in the deploy env when OAuth is on.
+- `MAX_LINEAGE_DEPTH` — server-side cap on lineage recursion depth. `-1` (default) = unlimited (unchanged behavior); set `>=0` to clamp unlimited/over-cap `depth` query params, bounding the cost of a single runaway request. **Treat a finite value as a required companion of `uvicorn --workers N`**: each worker is a separate process holding its own parsed manifest + its own result graph, so `N` concurrent deep (`depth=-1`) queries multiply peak memory (≈`N`× a single query's footprint) and can approach the instance memory ceiling — *worse* than single-worker if left unbounded. The shipped image runs `--workers 2`, so set a finite cap (or first verify 2-worker peak-memory headroom).
 
 > ⚠️ `.envrc` is gitignored but currently contains **real secrets** (Google OAuth + Looker SDK credentials). Do not commit it or echo its contents into other files; treat those values as compromised if exposed.
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,4 +29,4 @@ COPY src .
 COPY --from=node-builder /frontend/out dbt_column_lineage/frontend_out
 
 WORKDIR /app
-CMD ["uvicorn", "--app-dir", "src", "dbt_column_lineage.main:app", "--host", "0.0.0.0", "--port", "5000", "--timeout-keep-alive", "600"]
+CMD ["uvicorn", "--app-dir", "src", "dbt_column_lineage.main:app", "--host", "0.0.0.0", "--port", "5000", "--timeout-keep-alive", "600", "--workers", "2"]

--- a/frontend/src/components/pages/Cl.tsx
+++ b/frontend/src/components/pages/Cl.tsx
@@ -25,7 +25,7 @@ import '@xyflow/react/dist/style.css'
 import { Sidebar } from '@/components/organisms/Sidebar'
 import { Header } from '@/components/organisms/Header'
 import { useStore as useStoreZustand } from '@/store/zustand'
-import { Loader } from 'lucide-react'
+import { Loader, AlertTriangle } from 'lucide-react'
 import ToggleButtons from '@/components/ui/ToggleButtons'
 import { getColorClassForMaterialized, materializedTypes } from '@/lib/utils'
 import { DashboardNode, DashboardNodeProps } from '@/components/molecules/DashboardNode'
@@ -72,12 +72,15 @@ export const Cl = () => {
   const setRightMaxDepth = useStoreZustand((state) => state.setRightMaxDepth)
   const showColumn = useStoreZustand((state) => state.showColumn)
   const setShowColumn = useStoreZustand((state) => state.setShowColumn)
+  const truncated = useStoreZustand((state) => state.truncated)
+  const setTruncated = useStoreZustand((state) => state.setTruncated)
 
   const searchParams = useSearchParams()
 
   const handleFetchData = useCallback(async ({ dashboardId, sources, columns, showColumn, depth }: QueryParams) => {
     setNodes([])
     setEdges([])
+    setTruncated(false)
     // undefined が入っている場合は false に変換
     setShowColumn(Boolean(showColumn))
 
@@ -122,10 +125,11 @@ export const Cl = () => {
     }
     setNodes(data['nodes'])
     setEdges(data['edges'])
+    setTruncated(Boolean(data['truncated']))
 
     setNodesPositioned(false)
     return true
-  }, [setNodes, setEdges, setShowColumn, setMessage])
+  }, [setNodes, setEdges, setShowColumn, setMessage, setTruncated])
 
   const onNodesChange = useCallback(
     (changes: NodeChange[]) =>
@@ -191,6 +195,17 @@ export const Cl = () => {
               onConnect={onConnect}
               nodeTypes={nodeTypes}
             >
+              {truncated && (
+                <Panel position="top-center">
+                  <div
+                    className="flex items-center rounded border border-amber-400 bg-amber-100 px-4 py-2 text-xs text-amber-800 shadow-md"
+                    role="alert"
+                  >
+                    <AlertTriangle className="mr-2 h-4 w-4 shrink-0" />
+                    深さ上限に達したため、系統の一部を省略しています（さらに上流/下流があります）。
+                  </div>
+                </Panel>
+              )}
               <Panel position="top-left">
                 <div className="flex flex-col space-y-4">
                   <ToggleButtons />

--- a/frontend/src/store/zustand.ts
+++ b/frontend/src/store/zustand.ts
@@ -19,6 +19,7 @@ type State = {
   submitClicked: boolean
   isSubmitDisabled: boolean
   headerSearchDisplayMessage: string
+  truncated: boolean
 }
 
 type Action = {
@@ -36,6 +37,7 @@ type Action = {
   resetSubmitClicked: () => void
   setIsSubmitDisabled: (v: boolean) => void
   setHeaderSearchDisplayMessage: (v: string) => void
+  setTruncated: (v: boolean) => void
 }
 
 export const useStore = create<State & Action>()((set) => ({
@@ -53,6 +55,7 @@ export const useStore = create<State & Action>()((set) => ({
   submitClicked: false,
   isSubmitDisabled: false,
   headerSearchDisplayMessage: 'Select search model',
+  truncated: false,
   setOptions: (v:any) => set({options: v}),
   setShowColumn: (v:boolean) => set({showColumn: v}),
   setSidebarActive: (v:boolean) => set({sidebarActive: v}),
@@ -67,4 +70,5 @@ export const useStore = create<State & Action>()((set) => ({
   resetSubmitClicked: () => set({ submitClicked: false }),
   setIsSubmitDisabled: (v: boolean) => set({ isSubmitDisabled: v }),
   setHeaderSearchDisplayMessage: (v: string) => set({ headerSearchDisplayMessage: v }),
+  setTruncated: (v: boolean) => set({ truncated: v }),
 }))

--- a/src/dbt_column_lineage/constants.py
+++ b/src/dbt_column_lineage/constants.py
@@ -13,3 +13,13 @@ SQLGLOT_DIALECT=os.getenv('SQLGLOT_DIALECT', 'snowflake')
 # 汎用ツールなので固定せず、環境ごとに実行時に指定する。未設定ならメニューは出ない。
 # 例: https://docs.example.com/dbt/latest
 DBT_DOCS_BASE_URL = os.getenv('DBT_DOCS_BASE_URL')
+
+# セッション署名鍵。複数プロセス/インスタンス(uvicorn --workers や App Runner の
+# スケールアウト)で署名付きクッキーを共有するには、全プロセスで同一の固定値が必要。
+# 未設定時はプロセス毎にランダム生成(=単一プロセス前提の従来挙動)。
+SESSION_SECRET = os.getenv('SESSION_SECRET')
+
+# リネージ探索の深さ上限。-1 で無制限(従来挙動)。0 以上を設定すると、
+# request の depth が無制限(-1)または上限超のとき、この値にクランプして
+# 過大なクエリ1本がワーカーを占有/OOM するのを防ぐ。
+MAX_LINEAGE_DEPTH = int(os.getenv('MAX_LINEAGE_DEPTH', '-1'))

--- a/src/dbt_column_lineage/lineage.py
+++ b/src/dbt_column_lineage/lineage.py
@@ -28,6 +28,9 @@ class DbtSqlglot:
         self.edges = []
         self.target_dashboard_ids = []
         self.request_depth = request_depth
+        # depth 上限(request_depth)で実際に系統を打ち切ったか。未探索の依存が
+        # 残ったまま深さ制限で止まった場合のみ True(自然に末端へ達した場合は False)。
+        self.depth_truncated = False
 
         if self._initialized:
             return
@@ -152,7 +155,7 @@ class DbtSqlglot:
 
 
     def ret_edges_nodes(self) -> dict:
-        return {'edges': self.edges, 'nodes': self.nodes}
+        return {'edges': self.edges, 'nodes': self.nodes, 'truncated': self.depth_truncated}
 
 
     def cte_dependency(self, source: str, columns: []):
@@ -598,6 +601,9 @@ class DbtSqlglot:
         depth = depth + 1
         if self.request_depth != -1 and depth > self.request_depth:
             self.logger.info(f'depth={depth} reached')
+            # 未探索の依存が残っているなら、深さ上限で打ち切った
+            if deps_refs:
+                self.depth_truncated = True
             return
 
         for deps_unique_id in deps_refs:
@@ -679,6 +685,9 @@ class DbtSqlglot:
         next_found = False
         for after_base_column, after_next_sources_columns in after_next_sources_columns_dict.items():
             if self.request_depth != -1 and depth > self.request_depth:
+                # まだ辿るべき上流/下流(labels)があるのに深さ上限で止めた = 打ち切り
+                if after_next_sources_columns.get('labels'):
+                    self.depth_truncated = True
                 continue
             after_next_sources = after_next_sources_columns['labels']
             after_next_columns = after_next_sources_columns['columns']

--- a/src/dbt_column_lineage/main.py
+++ b/src/dbt_column_lineage/main.py
@@ -19,7 +19,7 @@ from requests.auth import HTTPBasicAuth
 from starlette.middleware.sessions import SessionMiddleware
 from starlette.exceptions import HTTPException as StarletteHTTPException
 
-from dbt_column_lineage.constants import USE_OAUTH, GOOGLE_CLIENT_ID, GOOGLE_CLIENT_SECRET, BASE_ROUTE
+from dbt_column_lineage.constants import USE_OAUTH, GOOGLE_CLIENT_ID, GOOGLE_CLIENT_SECRET, BASE_ROUTE, SESSION_SECRET, MAX_LINEAGE_DEPTH
 from dbt_column_lineage.lineage import DbtSqlglot
 from dbt_column_lineage.looker import Looker
 from dbt_column_lineage.utils import get_logger, get_redirect_url, get_diff_to_params, startup_dialect_check
@@ -38,8 +38,10 @@ app = FastAPI(lifespan=lifespan)
 # CORS設定
 app.add_middleware(CORSMiddleware, allow_origins=['*'], allow_credentials=True, allow_methods=['*'], allow_headers=['*'])
 
-# セッション管理のミドルウェア追加
-app.add_middleware(SessionMiddleware, secret_key=os.urandom(32).hex())
+# セッション管理のミドルウェア追加。
+# SESSION_SECRET があれば全プロセスで共有(複数ワーカー/インスタンスでセッション維持)、
+# 無ければ従来通りプロセス毎のランダム鍵。
+app.add_middleware(SessionMiddleware, secret_key=SESSION_SECRET or os.urandom(32).hex())
 
 logger = get_logger(app, __name__)
 
@@ -60,6 +62,16 @@ async def get_current_user(request: Request):
             raise HTTPException(status_code=401, detail='Not authenticated')
         return access_token
     return None
+
+
+def _capped_depth(depth: int) -> int:
+    """MAX_LINEAGE_DEPTH(>=0)が設定されていれば、無制限(-1)/上限超の depth をクランプする。
+    未設定(-1)なら depth をそのまま返す(従来の無制限挙動)。"""
+    if MAX_LINEAGE_DEPTH < 0:
+        return depth
+    if depth < 0 or depth > MAX_LINEAGE_DEPTH:
+        return MAX_LINEAGE_DEPTH
+    return depth
 
 
 @app.get('/healthcheck')
@@ -181,7 +193,7 @@ async def find_lineage(
     depth: int = Query(-1, description='depth of lineage', ge=-1),
     current_user: str = Depends(get_current_user)
 ):
-    dbt_sqlglot = DbtSqlglot(logger, request_depth=depth)
+    dbt_sqlglot = DbtSqlglot(logger, request_depth=_capped_depth(depth))
     if show_column:
         parsed_columns = json.loads(columns)
         for source in sources.split(','):
@@ -199,7 +211,7 @@ async def find_dashboard_lineage(
     depth: int = Query(-1, description='depth of lineage', ge=-1),
     current_user: str = Depends(get_current_user)
 ):
-    dbt_sqlglot = DbtSqlglot(logger, request_depth=depth)
+    dbt_sqlglot = DbtSqlglot(logger, request_depth=_capped_depth(depth))
     dbt_sqlglot.dashboard_lineage(dashboard_id)
     res = dbt_sqlglot.ret_edges_nodes()
     return JSONResponse(content=res)


### PR DESCRIPTION
## 背景
App Runner 上で高負荷時に 1 インスタンスが落ちうる構造的な脆さへの対策（Tier 0+1）。最有力メカニズムは、`async def` ハンドラが CPU 重い同期リネージ処理を `await`/スレッドプール無しで実行し**イベントループを塞ぐ** → バースト時に `/healthcheck`(5s×5) が返せず **App Runner がインスタンスを置換** → 処理中リクエストが落ちる、というもの。OOM も候補。CPUバウンド(GIL)なワークロードのため、並列性を上げる本命は「プロセス数」。

## 変更
- **Tier 0 — `SESSION_SECRET` env 化** (`constants.py`/`main.py`)
  セッションは署名付きクッキー(ステートレス)。鍵がプロセス毎ランダムだと、複数プロセス(`--workers`)/複数インスタンス(スケールアウト)で署名検証が割れて**セッションが壊れる**(ログイン失敗/API 401)。固定鍵を env から共有。未設定時は従来通りランダム鍵=単一プロセス挙動。`USE_OAUTH=true` の時に効く。
- **Tier 1a — `uvicorn --workers 2`** (`Dockerfile`)
  2vCPU を並列に使い、片方が重い処理中でも他方が `/healthcheck` を返す → インスタンスが殺されない。別プロセスなのでシングルトン競合も持ち込まない。
- **Tier 1b — `MAX_LINEAGE_DEPTH` env** (`constants.py`/`main.py`)
  `/lineage`・`/dashboard_lineage` の `depth` をサーバ側でクランプ。`-1`(既定)=無制限で従来挙動、`>=0` で無制限/上限超をクランプし暴走クエリ1本の占有/OOM を防ぐ。

## 検証
- `docker build --platform linux/x86_64` 成功 / コンテナ起動で **2 ワーカープロセス**確認 / `GET /`・`/healthcheck`・`/api/v1/schemas` すべて 200。
- **depth キャップ差分テスト**: `MAX_LINEAGE_DEPTH=2` の `depth=-1` が、無制限コンテナの `depth=2` と**同一ノード数(503)**。深さ単調性も確認(depth 1→278, 2→503, 3→656)。

## デプロイ時の必須設定
本番(`USE_OAUTH=true`)では **App Runner の env に `SESSION_SECRET` を設定**すること(未設定だと `--workers 2` でセッションが割れる)。必要に応じて `MAX_LINEAGE_DEPTH` も。詳細は CLAUDE.md 更新分参照。

🤖 Generated with [Claude Code](https://claude.com/claude-code)