### PR TITLE
fix(ui): 終端マーカー表示 + メッセージ英語統一

### DIFF
--- a/frontend/src/components/molecules/TableNode.tsx
+++ b/frontend/src/components/molecules/TableNode.tsx
@@ -7,6 +7,7 @@ import EventNodeHandle from '@/components/molecules/TableNodeColumnHandle'
 import EventNodeFrame from '@/components/molecules/TableNodeFrame'
 import TableNodeMoreColumns from '@/components/molecules/TableNodeMoreColumns'
 import TableNodeHandle from '@/components/molecules/TableNodeHandle'
+import TableNodeTerminalMarker from '@/components/molecules/TableNodeTerminalMarker'
 
 type TableNodeDataType = {
   name: string
@@ -74,7 +75,7 @@ export const TableNode: React.FC<TableNodeProps> = ({ data, id, selected }) => {
       docsUrl={data.docsUrl}
       content={
         <>
-          {(firstNodeTable != data.name) && (
+          {(firstNodeTable != data.name) ? (
             <TableNodeHandle
               type="source"
               position={Position.Left}
@@ -84,8 +85,10 @@ export const TableNode: React.FC<TableNodeProps> = ({ data, id, selected }) => {
               onConnect={() => handlePlusClickEventNodeHandle('', 'source')}
               onDelete={handleMinusClickEventNodeHandle}
             />
+          ) : (
+            <TableNodeTerminalMarker position={Position.Left} variant="table" />
           )}
-          {(lastNodeTable != data.name) && (
+          {(lastNodeTable != data.name) ? (
             <TableNodeHandle
               type="target"
               position={Position.Right}
@@ -95,6 +98,8 @@ export const TableNode: React.FC<TableNodeProps> = ({ data, id, selected }) => {
               onConnect={() => handlePlusClickEventNodeHandle('', 'target')}
               onDelete={handleMinusClickEventNodeHandle}
             />
+          ) : (
+            <TableNodeTerminalMarker position={Position.Right} variant="table" />
           )}
         </>
       }
@@ -150,7 +155,7 @@ export const TableNode: React.FC<TableNodeProps> = ({ data, id, selected }) => {
                 >
                   {column}
                 </p>
-                {( !data.last && !firstNodeColumns.includes(column)) && (
+                {( !data.last && !firstNodeColumns.includes(column)) ? (
                   <EventNodeHandle
                     type="source"
                     position={options.rankdir === 'LR' ? Position.Right : Position.Left}
@@ -160,8 +165,10 @@ export const TableNode: React.FC<TableNodeProps> = ({ data, id, selected }) => {
                     onDelete={() => handleMinusClickEventNodeHandle(column)}
                     onConnect={() => handlePlusClickEventNodeHandle(column, 'source')}
                   />
+                ) : (
+                  <TableNodeTerminalMarker position={options.rankdir === 'LR' ? Position.Right : Position.Left} />
                 )}
-                {( !data.first && !lastNodeColumns.includes(column)) && (
+                {( !data.first && !lastNodeColumns.includes(column)) ? (
                   <EventNodeHandle
                     type="target"
                     position={options.rankdir === 'LR' ? Position.Left : Position.Right}
@@ -171,6 +178,8 @@ export const TableNode: React.FC<TableNodeProps> = ({ data, id, selected }) => {
                     onDelete={() => handleMinusClickEventNodeHandle(column)}
                     onConnect={() => handlePlusClickEventNodeHandle(column, 'target')}
                   />
+                ) : (
+                  <TableNodeTerminalMarker position={options.rankdir === 'LR' ? Position.Left : Position.Right} />
                 )}
               </div>
             ))}

--- a/frontend/src/components/molecules/TableNodeTerminalMarker.tsx
+++ b/frontend/src/components/molecules/TableNodeTerminalMarker.tsx
@@ -1,0 +1,35 @@
+'use client'
+import React, { memo } from 'react'
+import { Position } from '@xyflow/react'
+
+interface TableNodeTerminalMarkerProps {
+  position: Position
+  // column 行(top:50%)か table ヘッダ(top:22px)かで縦位置を合わせる
+  variant?: 'column' | 'table'
+}
+
+// 「+」で展開してもその先が無い(終端)ときに、ハンドルを黙って消す代わりに
+// 出す静的マーカー。ハンドルと同じ 24px の枠を占有して行のレイアウトを崩さない。
+// クリック不可・ミュートなグレーの終端キャップで「ここで系統が終わり」を示す。
+const TableNodeTerminalMarker: React.FC<TableNodeTerminalMarkerProps> = ({ position, variant = 'column' }) => {
+  return (
+    <div
+      title="No further lineage"
+      style={{
+        position: 'absolute',
+        [position === Position.Left ? 'left' : 'right']: '-2px',
+        top: variant === 'table' ? '22px' : '50%',
+        transform: 'translateY(-50%)',
+        zIndex: 1,
+        pointerEvents: 'none',
+      }}
+    >
+      <div className="w-6 h-6 flex items-center justify-center">
+        {/* 接続線の末端キャップ(短い縦バー) */}
+        <span className="block w-[3px] h-3.5 rounded-full bg-gray-300" />
+      </div>
+    </div>
+  )
+}
+
+export default memo(TableNodeTerminalMarker)

--- a/frontend/src/components/pages/Cl.tsx
+++ b/frontend/src/components/pages/Cl.tsx
@@ -119,7 +119,7 @@ export const Cl = () => {
       }
     } catch (e) {
       console.error('Failed to fetch lineage:', e)
-      setMessage('通信に失敗しました', 'error')
+      setMessage('Failed to fetch data', 'error')
       setTimeout(() => setMessage(null, null), 3000)
       return false
     }
@@ -181,8 +181,8 @@ export const Cl = () => {
               <div className="absolute inset-0 z-10 flex items-center justify-center bg-white/60 backdrop-blur-[1px]">
                 <div className="flex flex-col items-center rounded-lg bg-white px-6 py-4 shadow-lg border border-gray-200">
                   <Loader className="animate-spin text-blue-600" size={28} />
-                  <span className="mt-2 text-sm font-medium text-gray-700">読み込み中…</span>
-                  <span className="mt-1 text-xs text-gray-500">モデルによっては初回の取得に時間がかかります</span>
+                  <span className="mt-2 text-sm font-medium text-gray-700">Loading…</span>
+                  <span className="mt-1 text-xs text-gray-500">The first load can take a while for some models</span>
                 </div>
               </div>
             )}
@@ -202,7 +202,7 @@ export const Cl = () => {
                     role="alert"
                   >
                     <AlertTriangle className="mr-2 h-4 w-4 shrink-0" />
-                    深さ上限に達したため、系統の一部を省略しています（さらに上流/下流があります）。
+                    Lineage was truncated — some upstream/downstream nodes are omitted.
                   </div>
                 </Panel>
               )}

--- a/frontend/src/components/pages/Cte.tsx
+++ b/frontend/src/components/pages/Cte.tsx
@@ -325,7 +325,7 @@ export const Cte = () => {
       }
     } catch (e) {
       console.error('Failed to fetch CTE:', e)
-      setMessage('通信に失敗しました', 'error')
+      setMessage('Failed to fetch data', 'error')
       setTimeout(() => setMessage(null, null), 3000)
       return false
     }

--- a/frontend/src/hooks/useEventNodeOperations.ts
+++ b/frontend/src/hooks/useEventNodeOperations.ts
@@ -95,7 +95,7 @@ export const useEventNodeOperations = (id: string) => {
     } catch (e) {
       // 非JSONレスポンス(502/504やログインHTML等)や通信失敗でも必ずローディングを解除する
       console.error('Failed to fetch reverse lineage:', e)
-      alert('リネージの取得に失敗しました')
+      alert('Failed to fetch lineage')
     } finally {
       setLoading(false)
     }
@@ -137,7 +137,7 @@ export const useEventNodeOperations = (id: string) => {
     } catch (e) {
       // 非JSONレスポンス(502/504やログインHTML等)や通信失敗でも必ずローディングを解除する
       console.error('Failed to fetch single lineage:', e)
-      alert('リネージの取得に失敗しました')
+      alert('Failed to fetch lineage')
     } finally {
       setLoading(false)
     }


### PR DESCRIPTION
細かいUI修正2点。

## 1. 終端到達がわかりにくい問題
`+` を押して上流/下流がもう無い(空応答)とき、これまでハンドルが**黙って消える**だけで「終端なのか/読み込み中なのか/壊れたのか」区別がつかなかった。

→ 消す代わりに、同じ24px枠に**静的な終端キャップ**(クリック不可・グレー、`title="No further lineage"`)を表示。列ハンドル・テーブルハンドルの両方、消えていた側に出す。判定は既存の `firstNodeColumns`/`lastNodeColumns`/`firstNodeTable`/`lastNodeTable`(クリック後の空応答で記録)をそのまま利用。

実装は「ハンドル描画条件の `else`」かつ位置はハンドルと同じ式から導出 → マーカー ⟺ ハンドル非表示 が構造的に保証され、左右取り違え/二重表示が起きない。新規 `TableNodeTerminalMarker`。

## 2. メッセージが日本語で浮いていた問題
UIは大半が英語(login/コピー系等)なのに、一部だけ日本語だった。ユーザー向け文字列を全て英語化:

| 箇所 | before → after |
|---|---|
| ローディング | `読み込み中…` → `Loading…` / 補足 → `The first load can take a while for some models` |
| 省略注記 | `深さ上限に達したため…` → `Lineage was truncated — some upstream/downstream nodes are omitted.`(時間予算でも立つため depth 限定をやめ汎用化) |
| 取得失敗トースト | `通信に失敗しました` → `Failed to fetch data`(Cl/Cte) |
| alertダイアログ | `リネージの取得に失敗しました` → `Failed to fetch lineage`(×2) |

開発コメント(`//`)の日本語は据え置き。

## 確認
`npm run lint`(0 warnings)・`npm run build`(静的エクスポート)クリーン。

🤖 Generated with [Claude Code](https://claude.com/claude-code)