### PR TITLE
feat(ui): リネージ編集モード（設計フェーズ向け DFD オーサリング）

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,9 +50,11 @@ The `dbt-column-lineage` entrypoint (`main.cli`, Typer) has commands: `run` (lau
 
 `pyproject.toml` declares a `dev` extra (`pytest`, `black`, `isort`). Note `.gitignore` has `test/*.py` (top-level only), so ad-hoc scratch scripts directly in `test/` are ignored — but the real unit suite lives in **`test/unit/`** (a subdir, tracked).
 
+A local virtualenv lives at **`.venv/`** (gitignored) with the backend deps (`sqlglot`, `fastapi`, …) and `pytest` already installed. Run the suite through it — the system `python3` does **not** have `sqlglot`, so `python3 -m pytest` fails at import collection:
+
 ```bash
-pip install -e ".[dev]"     # or: pip install pytest
-pytest                       # testpaths = ["test/unit"] (see pyproject)
+.venv/bin/python -m pytest test/unit -q   # 27 passing; testpaths = ["test/unit"] (see pyproject)
+# fresh env instead: pip install -e ".[dev]" then pytest
 ```
 
 `test/unit/` runs without a real dbt project/warehouse: `conftest.py` points `DbtSqlglot` at a tiny synthetic `manifest.json`/`catalog.json` under `test/unit/fixtures/target/` via `DBT_PROJECT_DIR`, and resets the `DbtSqlglot._instance` singleton per test. Current coverage centers on the **phantom-CTE filter** (the UNPIVOT lineage workaround for sqlglot#7727) plus a pure-sqlglot regression guard that fails if upstream sqlglot ever starts tracing UNPIVOT (a signal to drop the workaround). There is no CI test gate yet.

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -15,6 +15,7 @@
         "dagre": "^0.8.5",
         "html-to-image": "^1.11.11",
         "lucide-react": "^1.17.0",
+        "lz-string": "^1.5.0",
         "next": "^16.2.9",
         "react": "^19.2.7",
         "react-dom": "^19.2.7",
@@ -401,30 +402,6 @@
         "crelt": "^1.0.6",
         "style-mod": "^4.1.0",
         "w3c-keyname": "^2.2.4"
-      }
-    },
-    "node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.0.tgz",
-      "integrity": "sha512-55coeOFKHv1ywEcUXJtWU5f+Jr/W5tZDvZig8DLKSwUN1JpROQ4rk/SNOQiFWmaR/VKF4zuFyW1B8JduOSv6Pg==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
@@ -4233,6 +4210,7 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -6039,6 +6017,15 @@
       "license": "ISC",
       "peerDependencies": {
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "license": "MIT",
+      "bin": {
+        "lz-string": "bin/bin.js"
       }
     },
     "node_modules/magic-string": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,6 +16,7 @@
     "dagre": "^0.8.5",
     "html-to-image": "^1.11.11",
     "lucide-react": "^1.17.0",
+    "lz-string": "^1.5.0",
     "next": "^16.2.9",
     "react": "^19.2.7",
     "react-dom": "^19.2.7",

--- a/frontend/src/components/molecules/EditableTableNode.tsx
+++ b/frontend/src/components/molecules/EditableTableNode.tsx
@@ -1,0 +1,164 @@
+'use client'
+import React, { useCallback, useMemo } from 'react'
+import { Handle, Node, NodeProps, Position, useReactFlow } from '@xyflow/react'
+import { Trash2, Plus, X } from 'lucide-react'
+import { useStore as useStoreZustand } from '@/store/zustand'
+
+// 設計フェーズで開発者が手で足す「これから作るテーブル」。
+// 属性はテーブル名とカラム名のみ。ハンドル ID は実テーブルノードと同じ
+// `${column}__source` / `${column}__target` 規約に合わせ、エッジが整合・再現できるようにする。
+export type EditableTableNodeDataType = {
+  name: string
+  columns: string[]
+  pks?: string[] // 主キーのカラム名。複数指定で複合主キー
+  custom: true
+  manual: true
+}
+
+export type EditableTableNodeFlowType = Node<EditableTableNodeDataType, 'editableTableNode'>
+export type EditableTableNodeProps = NodeProps<EditableTableNodeFlowType>
+
+const dot: React.CSSProperties = {
+  width: 9,
+  height: 9,
+  background: '#7c3aed',
+  border: '2px solid #fff',
+}
+
+export const EditableTableNode: React.FC<EditableTableNodeProps> = ({ data, id, selected }) => {
+  const editMode = useStoreZustand((state) => state.editMode)
+  const options = useStoreZustand((state) => state.options)
+  const { updateNodeData, setNodes } = useReactFlow()
+
+  // rankdir に合わせてカラムハンドルの左右を実テーブルノードと揃える
+  const sourcePos = options.rankdir === 'LR' ? Position.Right : Position.Left
+  const targetPos = options.rankdir === 'LR' ? Position.Left : Position.Right
+
+  const columns = useMemo(() => data.columns || [], [data.columns])
+  const pks = useMemo(() => data.pks || [], [data.pks])
+
+  const setName = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => updateNodeData(id, { name: e.target.value }),
+    [id, updateNodeData],
+  )
+  const renameColumn = useCallback(
+    (index: number, value: string) => {
+      const old = columns[index]
+      updateNodeData(id, {
+        columns: columns.map((c, i) => (i === index ? value : c)),
+        // PK 指定もリネームに追従させる
+        pks: pks.includes(old) ? pks.map((p) => (p === old ? value : p)) : pks,
+      })
+    },
+    [id, columns, pks, updateNodeData],
+  )
+  const addColumn = useCallback(
+    () => updateNodeData(id, { columns: [...columns, `column_${columns.length + 1}`] }),
+    [id, columns, updateNodeData],
+  )
+  const removeColumn = useCallback(
+    (index: number) => {
+      const col = columns[index]
+      updateNodeData(id, {
+        columns: columns.filter((_, i) => i !== index),
+        pks: pks.filter((p) => p !== col),
+      })
+    },
+    [id, columns, pks, updateNodeData],
+  )
+  const togglePk = useCallback(
+    (column: string) =>
+      updateNodeData(id, {
+        pks: pks.includes(column) ? pks.filter((p) => p !== column) : [...pks, column],
+      }),
+    [id, pks, updateNodeData],
+  )
+  const deleteNode = useCallback(
+    () => setNodes((nds) => nds.filter((n) => n.id !== id)),
+    [id, setNodes],
+  )
+
+  return (
+    <div
+      className={`relative flex flex-col rounded-sm border-2 border-dashed border-violet-500 bg-white text-sm ${selected ? 'shadow-lg' : 'shadow-md'}`}
+      style={{ minWidth: 200 }}
+    >
+      {/* テーブルレベルのハンドル(テーブル同士をつなぐ用) */}
+      <Handle type="target" position={Position.Right} id={`${id}__target`} isConnectable style={{ ...dot, top: 16 }} />
+      <Handle type="source" position={Position.Left} id={`${id}__source`} isConnectable style={{ ...dot, top: 16 }} />
+
+      <div className="flex items-center justify-between bg-violet-50 px-3 py-2">
+        {editMode ? (
+          <input
+            className="nodrag w-full rounded-sm border border-violet-300 bg-white px-1 py-0.5 text-sm font-semibold text-gray-800 focus:outline-hidden"
+            value={data.name}
+            placeholder="table name"
+            onChange={setName}
+          />
+        ) : (
+          <span className="font-semibold text-gray-800" title={data.name}>{data.name || '(no name)'}</span>
+        )}
+        {editMode && selected && (
+          <button
+            className="nodrag ml-2 shrink-0 rounded-full p-1 text-gray-500 hover:bg-red-50 hover:text-red-600"
+            onClick={deleteNode}
+            title="Delete table"
+          >
+            <Trash2 size={14} />
+          </button>
+        )}
+      </div>
+
+      <div className="py-1">
+        {columns.map((column, index) => (
+          <div key={index} className="relative flex items-center px-4 py-1.5">
+            <Handle type="target" position={targetPos} id={`${column}__target`} isConnectable style={dot} />
+            {editMode ? (
+              <input
+                className="nodrag grow rounded-sm border border-gray-200 bg-white px-1 py-0.5 text-xs text-gray-700 focus:outline-hidden"
+                value={column}
+                placeholder="column"
+                onChange={(e) => renameColumn(index, e.target.value)}
+              />
+            ) : (
+              <span className={`grow text-xs ${pks.includes(column) ? 'font-semibold text-gray-800' : 'text-gray-700'}`}>{column}</span>
+            )}
+            {editMode ? (
+              <button
+                className={`nodrag ml-1 shrink-0 rounded-sm px-1 text-[10px] font-bold ${
+                  pks.includes(column) ? 'bg-amber-400 text-white' : 'border border-gray-300 text-gray-400 hover:border-amber-400 hover:text-amber-500'
+                }`}
+                onClick={() => togglePk(column)}
+                title="Toggle primary key"
+              >
+                PK
+              </button>
+            ) : (
+              pks.includes(column) && (
+                <span className="ml-1 shrink-0 rounded-sm bg-amber-400 px-1 text-[10px] font-bold text-white">PK</span>
+              )
+            )}
+            {editMode && (
+              <button
+                className="nodrag ml-1 shrink-0 text-gray-400 hover:text-red-600"
+                onClick={() => removeColumn(index)}
+                title="Remove column"
+              >
+                <X size={13} />
+              </button>
+            )}
+            <Handle type="source" position={sourcePos} id={`${column}__source`} isConnectable style={dot} />
+          </div>
+        ))}
+        {editMode && (
+          <button
+            className="nodrag mx-4 my-1 flex items-center gap-1 text-xs font-medium text-violet-600 hover:text-violet-800"
+            onClick={addColumn}
+          >
+            <Plus size={13} /> add column
+          </button>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/molecules/NoteNode.tsx
+++ b/frontend/src/components/molecules/NoteNode.tsx
@@ -1,0 +1,68 @@
+'use client'
+import React, { useCallback } from 'react'
+import { Handle, Node, NodeProps, Position, useReactFlow } from '@xyflow/react'
+import { Trash2 } from 'lucide-react'
+import { useStore as useStoreZustand } from '@/store/zustand'
+
+// 設計図に添えるメモ/注釈。任意で破線コネクタ用ハンドルを持ち、対象に結びつけられる。
+export type NoteNodeDataType = {
+  text: string
+  custom: true
+  manual: true
+}
+
+export type NoteNodeFlowType = Node<NoteNodeDataType, 'noteNode'>
+export type NoteNodeProps = NodeProps<NoteNodeFlowType>
+
+const dot: React.CSSProperties = {
+  width: 8,
+  height: 8,
+  background: '#d97706',
+  border: '2px solid #fff',
+}
+
+export const NoteNode: React.FC<NoteNodeProps> = ({ data, id, selected }) => {
+  const editMode = useStoreZustand((state) => state.editMode)
+  const { updateNodeData, setNodes } = useReactFlow()
+
+  const onTextChange = useCallback(
+    (e: React.ChangeEvent<HTMLTextAreaElement>) => updateNodeData(id, { text: e.target.value }),
+    [id, updateNodeData],
+  )
+  const deleteNode = useCallback(
+    () => setNodes((nds) => nds.filter((n) => n.id !== id)),
+    [id, setNodes],
+  )
+
+  return (
+    <div
+      className={`relative rounded-sm border border-amber-300 ${selected ? 'shadow-lg' : 'shadow-md'}`}
+      style={{ background: '#fffbeb', minWidth: 160, maxWidth: 280, padding: '8px 10px' }}
+    >
+      <Handle type="source" position={Position.Bottom} id={`${id}__source`} isConnectable style={dot} />
+      <Handle type="target" position={Position.Top} id={`${id}__target`} isConnectable style={dot} />
+
+      {editMode ? (
+        <textarea
+          className="nodrag w-full resize-y border-none bg-transparent text-xs text-amber-900 focus:outline-hidden"
+          rows={3}
+          value={data.text}
+          placeholder="note…"
+          onChange={onTextChange}
+        />
+      ) : (
+        <div className="text-xs whitespace-pre-wrap text-amber-900">{data.text || '(empty note)'}</div>
+      )}
+
+      {editMode && selected && (
+        <button
+          className="nodrag absolute -top-3 -right-3 flex h-6 w-6 items-center justify-center rounded-full border border-gray-300 bg-white text-gray-600 shadow-sm hover:bg-red-50 hover:text-red-600"
+          onClick={deleteNode}
+          title="Delete note"
+        >
+          <Trash2 size={13} />
+        </button>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/components/organisms/CanvasActions.tsx
+++ b/frontend/src/components/organisms/CanvasActions.tsx
@@ -1,0 +1,69 @@
+'use client'
+import React, { useCallback } from 'react'
+import { useReactFlow } from '@xyflow/react'
+import { toBlob } from 'html-to-image'
+import { Camera, Pencil } from 'lucide-react'
+import { useStore as useStoreZustand } from '@/store/zustand'
+import { Tooltip } from '@/components/ui/Tooltip'
+
+// キャンバス右下に出す丸アイコンのアクション群。
+// Edit(設計モードの入口・ON で紫)を主、Copy(画像コピー)を副として置く。
+export const CanvasActions = () => {
+  const { fitView } = useReactFlow()
+  const setMessage = useStoreZustand((state) => state.setMessage)
+  const editMode = useStoreZustand((state) => state.editMode)
+  const setEditMode = useStoreZustand((state) => state.setEditMode)
+
+  const copyToClipboard = useCallback(async () => {
+    const flowElement = document.querySelector('.react-flow__viewport') as HTMLElement
+    // ビューをフィットさせてから画像化する
+    window.requestAnimationFrame(() => fitView())
+    await new Promise(resolve => setTimeout(resolve, 100))
+    const blob = await toBlob(flowElement, { backgroundColor: '#fff' })
+    if (blob) {
+      try {
+        const data = [new window.ClipboardItem({ 'image/png': blob })]
+        await navigator.clipboard.write(data)
+        const params = new URLSearchParams(window.location.search).toString()
+        setMessage('Successfully copied to clipboard!:\n\n' + params, 'success')
+        setTimeout(() => setMessage(null, null), 6000)
+      } catch (err) {
+        setMessage('Failed to copy to clipboard', 'error')
+        console.error('Failed to copy:', err)
+        setTimeout(() => setMessage(null, null), 3000)
+      }
+    }
+  }, [fitView, setMessage])
+
+  const circle = 'flex items-center justify-center rounded-full border shadow-md transition-colors'
+
+  return (
+    <div className="flex flex-col items-end gap-2">
+      <Tooltip label="Copy the canvas as an image" side="left">
+        <button
+          type="button"
+          onClick={copyToClipboard}
+          className={`${circle} h-11 w-11 border-gray-200 bg-white text-gray-600 hover:bg-gray-50`}
+          aria-label="Copy to clipboard"
+        >
+          <Camera size={18} />
+        </button>
+      </Tooltip>
+      <Tooltip label={editMode ? 'Exit edit mode' : 'Edit — add tables, notes, and connections'} side="left">
+        <button
+          type="button"
+          onClick={() => setEditMode(!editMode)}
+          className={`${circle} h-11 w-11 ${
+            editMode
+              ? 'border-violet-700 bg-violet-600 text-white hover:bg-violet-700'
+              : 'border-gray-200 bg-white text-gray-700 hover:bg-gray-50'
+          }`}
+          aria-label="Toggle edit mode"
+          aria-pressed={editMode}
+        >
+          <Pencil size={18} />
+        </button>
+      </Tooltip>
+    </div>
+  )
+}

--- a/frontend/src/components/organisms/EditToolbar.tsx
+++ b/frontend/src/components/organisms/EditToolbar.tsx
@@ -136,8 +136,8 @@ export const EditToolbar: React.FC<EditToolbarProps> = ({ nodes, edges, setNodes
   // Edit トグル本体は ToggleButtons の行に置いてあるので、ここでは編集中のアクション群だけ出す
   if (!editMode) return null
 
-  // 「作る」=紫チップ(設計ツールのパレット)。「保存・共有」=静かなゴースト。色のゾーニングで2群を区別する。
-  const createBtn = 'flex items-center gap-1 rounded-md bg-violet-50 px-2.5 py-1.5 text-xs font-semibold text-violet-700 ring-1 ring-violet-200 hover:bg-violet-100'
+  // 「作る」=紫テキスト(フラット)。「保存・共有」=グレー。色で2群を区別しつつ、ツールバーらしく軽く保つ。
+  const createBtn = 'flex items-center gap-1 rounded-md px-2.5 py-1.5 text-xs font-semibold text-violet-700 hover:bg-violet-50'
   const saveBtn = 'flex items-center gap-1 rounded-md px-2.5 py-1.5 text-xs font-medium text-gray-600 hover:bg-gray-100'
 
   return (

--- a/frontend/src/components/organisms/EditToolbar.tsx
+++ b/frontend/src/components/organisms/EditToolbar.tsx
@@ -136,19 +136,19 @@ export const EditToolbar: React.FC<EditToolbarProps> = ({ nodes, edges, setNodes
   // Edit トグル本体は ToggleButtons の行に置いてあるので、ここでは編集中のアクション群だけ出す
   if (!editMode) return null
 
-  // 「作る」系は強調(violet)、「保存・共有」系は中立(gray)で見分けやすくする
-  const createBtn = 'flex items-center gap-1 rounded-md px-2.5 py-1.5 text-xs font-semibold text-violet-700 hover:bg-violet-50'
+  // 「作る」=紫チップ(設計ツールのパレット)。「保存・共有」=静かなゴースト。色のゾーニングで2群を区別する。
+  const createBtn = 'flex items-center gap-1 rounded-md bg-violet-50 px-2.5 py-1.5 text-xs font-semibold text-violet-700 ring-1 ring-violet-200 hover:bg-violet-100'
   const saveBtn = 'flex items-center gap-1 rounded-md px-2.5 py-1.5 text-xs font-medium text-gray-600 hover:bg-gray-100'
 
   return (
     <div className="flex flex-col items-center gap-1">
-      <div className="flex items-center gap-0.5 rounded-lg border border-gray-200 bg-white/95 px-1.5 py-1 shadow-md backdrop-blur-sm">
-        {/* 作る */}
+      <div className="flex items-center gap-1 rounded-lg border border-gray-200 bg-white/95 px-1.5 py-1 shadow-md backdrop-blur-sm">
+        {/* 作る(紫チップ): 左上の表示トグル"Table"と区別するため + を付け「追加」と明示 */}
         <button type="button" className={createBtn} onClick={addTableNode} {...describe('Add a planned table — set its name and columns')}>
-          <Table size={15} /> Table
+          <Table size={15} /> + Table
         </button>
         <button type="button" className={createBtn} onClick={addNoteNode} {...describe('Add a sticky note / annotation')}>
-          <StickyNote size={15} /> Note
+          <StickyNote size={15} /> + Note
         </button>
 
         <span className="mx-1 h-6 w-px bg-gray-200" aria-hidden />

--- a/frontend/src/components/organisms/EditToolbar.tsx
+++ b/frontend/src/components/organisms/EditToolbar.tsx
@@ -142,7 +142,7 @@ export const EditToolbar: React.FC<EditToolbarProps> = ({ nodes, edges, setNodes
 
   return (
     <div className="flex flex-col items-center gap-1">
-      <div className="flex items-center gap-1 rounded-lg border border-gray-200 bg-white/95 px-1.5 py-1 shadow-md backdrop-blur-sm">
+      <div className="flex items-center gap-1 rounded-lg border border-gray-200 bg-white/95 px-1.5 py-0 shadow-md backdrop-blur-sm">
         {/* 作る(紫チップ): 左上の表示トグル"Table"と区別するため + を付け「追加」と明示 */}
         <button type="button" className={createBtn} onClick={addTableNode} {...describe('Add a planned table — set its name and columns')}>
           <Table size={15} /> + Table

--- a/frontend/src/components/organisms/EditToolbar.tsx
+++ b/frontend/src/components/organisms/EditToolbar.tsx
@@ -1,0 +1,177 @@
+'use client'
+import React, { useCallback, useEffect, useRef, useState } from 'react'
+import { Edge, Node, useReactFlow } from '@xyflow/react'
+import { Table, StickyNote, Share2, Download, Upload } from 'lucide-react'
+import { useStore as useStoreZustand } from '@/store/zustand'
+import { serializeDesign, exportDesignJson, importDesignJson, DesignSnapshot, DesignView } from '@/lib/design'
+
+// 共有 URL の長さしきい値(文字数)。ゲートウェイは URL+ヘッダで 8KB 程度が定番上限なので
+// 余裕を見て SOFT/HARD を設ける。超えたら Export を促す。
+const URL_SOFT_LIMIT = 2000
+const URL_HARD_LIMIT = 8000
+
+// バー下の説明エリアの既定文言(どのボタンにもホバーしていないとき)
+const DEFAULT_HINT = 'Drag a column dot to another to connect · click a name to edit · toggle PK for keys'
+
+interface EditToolbarProps {
+  nodes: Node[]
+  edges: Edge[]
+  setNodes: (updater: (nds: Node[]) => Node[]) => void
+  applySnapshot: (snapshot: DesignSnapshot) => void
+}
+
+export const EditToolbar: React.FC<EditToolbarProps> = ({ nodes, edges, setNodes, applySnapshot }) => {
+  const { screenToFlowPosition } = useReactFlow()
+  const editMode = useStoreZustand((state) => state.editMode)
+  const showColumn = useStoreZustand((state) => state.showColumn)
+  const options = useStoreZustand((state) => state.options)
+  const sourceMode = useStoreZustand((state) => state.sourceMode)
+  const setMessage = useStoreZustand((state) => state.setMessage)
+  const fileInputRef = useRef<HTMLInputElement>(null)
+  // 説明エリア: ホバー中のボタン説明 / 起動直後だけ出る既定ヒント(数秒で消える)。
+  const [hovered, setHovered] = useState<string | null>(null)
+  const [showDefault, setShowDefault] = useState(true)
+  // Edit に入った直後だけ既定ヒントを表示し、6秒で自動的に消す
+  useEffect(() => {
+    const t = setTimeout(() => setShowDefault(false), 6000)
+    return () => clearTimeout(t)
+  }, [])
+  const describe = useCallback(
+    (text: string) => ({
+      onMouseEnter: () => setHovered(text),
+      onMouseLeave: () => setHovered(null),
+    }),
+    [],
+  )
+  const hint = hovered ?? (showDefault ? DEFAULT_HINT : null)
+
+  const currentView = useCallback((): DesignView => ({
+    showColumn,
+    rankdir: options.rankdir,
+    sourceMode,
+  }), [showColumn, options.rankdir, sourceMode])
+
+  // ビューポート中央のフロー座標を返す
+  const centerPosition = useCallback(
+    () => screenToFlowPosition({ x: window.innerWidth / 2, y: window.innerHeight / 2 }),
+    [screenToFlowPosition],
+  )
+
+  const addTableNode = useCallback(() => {
+    const id = `table-${Date.now()}`
+    setNodes((nds) => [
+      ...nds,
+      {
+        id,
+        type: 'editableTableNode',
+        position: centerPosition(),
+        data: { name: '', columns: [], custom: true, manual: true },
+      } as Node,
+    ])
+  }, [centerPosition, setNodes])
+
+  const addNoteNode = useCallback(() => {
+    const id = `note-${Date.now()}`
+    setNodes((nds) => [
+      ...nds,
+      { id, type: 'noteNode', position: centerPosition(), data: { text: '', custom: true, manual: true } } as Node,
+    ])
+  }, [centerPosition, setNodes])
+
+  const flash = useCallback((msg: string, type: 'success' | 'error' | 'info') => {
+    setMessage(msg, type)
+    setTimeout(() => setMessage(null, null), 3000)
+  }, [setMessage])
+
+  const shareUrl = useCallback(async () => {
+    const encoded = serializeDesign(nodes, edges, currentView())
+    const url = `${window.location.origin}/cl?design=${encoded}`
+    // 上限超過のリンクを黙って渡さない。ハードはコピーせずエラー、ソフトはコピーするが警告。
+    if (url.length > URL_HARD_LIMIT) {
+      flash(`Design too large for a URL (${(url.length / 1024).toFixed(1)}KB). Use Export instead.`, 'error')
+      return
+    }
+    try {
+      await navigator.clipboard.writeText(url)
+      if (url.length > URL_SOFT_LIMIT) {
+        flash('URL copied, but it may be too long for some gateways/chat. Use Export for large designs.', 'info')
+      } else {
+        flash('Design URL copied to clipboard', 'success')
+      }
+    } catch {
+      // クリップボード API が使えない環境(非 https 等)では URL に反映してフォールバック
+      window.history.replaceState(null, '', url)
+      flash('Clipboard unavailable — URL updated in address bar', 'info')
+    }
+  }, [nodes, edges, currentView, flash])
+
+  const exportJson = useCallback(() => {
+    const json = exportDesignJson(nodes, edges, currentView())
+    const blob = new Blob([json], { type: 'application/json' })
+    const url = URL.createObjectURL(blob)
+    const a = document.createElement('a')
+    a.href = url
+    a.download = 'lineage-design.json'
+    a.click()
+    URL.revokeObjectURL(url)
+  }, [nodes, edges, currentView])
+
+  const onImportFile = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0]
+    if (!file) return
+    const reader = new FileReader()
+    reader.onload = () => {
+      const snapshot = importDesignJson(String(reader.result))
+      if (!snapshot) {
+        flash('Invalid design file', 'error')
+        return
+      }
+      applySnapshot(snapshot)
+      flash('Design imported', 'success')
+    }
+    reader.readAsText(file)
+    e.target.value = ''
+  }, [applySnapshot, flash])
+
+  // Edit トグル本体は ToggleButtons の行に置いてあるので、ここでは編集中のアクション群だけ出す
+  if (!editMode) return null
+
+  // 「作る」系は強調(violet)、「保存・共有」系は中立(gray)で見分けやすくする
+  const createBtn = 'flex items-center gap-1 rounded-md px-2.5 py-1.5 text-xs font-semibold text-violet-700 hover:bg-violet-50'
+  const saveBtn = 'flex items-center gap-1 rounded-md px-2.5 py-1.5 text-xs font-medium text-gray-600 hover:bg-gray-100'
+
+  return (
+    <div className="flex flex-col items-center gap-1">
+      <div className="flex items-center gap-0.5 rounded-lg border border-gray-200 bg-white/95 px-1.5 py-1 shadow-md backdrop-blur-sm">
+        {/* 作る */}
+        <button type="button" className={createBtn} onClick={addTableNode} {...describe('Add a planned table — set its name and columns')}>
+          <Table size={15} /> Table
+        </button>
+        <button type="button" className={createBtn} onClick={addNoteNode} {...describe('Add a sticky note / annotation')}>
+          <StickyNote size={15} /> Note
+        </button>
+
+        <span className="mx-1 h-6 w-px bg-gray-200" aria-hidden />
+
+        {/* 保存・共有 */}
+        <button type="button" className={saveBtn} onClick={shareUrl} {...describe('Copy a shareable URL of this design')}>
+          <Share2 size={15} /> Share
+        </button>
+        <button type="button" className={saveBtn} onClick={exportJson} {...describe('Download the design as JSON — for large designs / Git')}>
+          <Download size={15} /> Export
+        </button>
+        <button type="button" className={saveBtn} onClick={() => fileInputRef.current?.click()} {...describe('Load a design from a JSON file')}>
+          <Upload size={15} /> Import
+        </button>
+        <input ref={fileInputRef} type="file" accept="application/json,.json" className="hidden" onChange={onImportFile} />
+      </div>
+
+      {/* 説明エリア: 起動直後の既定ヒント(数秒で消える) or ホバー中のボタン説明。idle 時は非表示 */}
+      {hint && (
+        <div className="rounded bg-gray-800/85 px-2 py-0.5 text-[10px] font-medium text-white shadow-sm">
+          {hint}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/components/organisms/Sidebar.tsx
+++ b/frontend/src/components/organisms/Sidebar.tsx
@@ -52,9 +52,13 @@ const getLayoutedElements = (nodes: Node[], edges: Edge[], options: {rankdir: st
         break;
     }
 
-    node.position = {
-      x: nodeWithPosition.x - nodeWithPosition.width / 2 + Math.random() / 1000,
-      y: nodeWithPosition.y - nodeWithPosition.height / 2,
+    // 手動配置(ドラッグ済み・URL復元・カスタムノード = data.manual)の位置は
+    // dagre で上書きしない。スナップショット再現性のため。
+    if (!(node.data as { manual?: boolean } | undefined)?.manual) {
+      node.position = {
+        x: nodeWithPosition.x - nodeWithPosition.width / 2,
+        y: nodeWithPosition.y - nodeWithPosition.height / 2,
+      }
     }
 
     return node

--- a/frontend/src/components/pages/Cl.tsx
+++ b/frontend/src/components/pages/Cl.tsx
@@ -29,6 +29,11 @@ import { Loader, AlertTriangle } from 'lucide-react'
 import ToggleButtons from '@/components/ui/ToggleButtons'
 import { getColorClassForMaterialized, materializedTypes } from '@/lib/utils'
 import { DashboardNode, DashboardNodeProps } from '@/components/molecules/DashboardNode'
+import { EditableTableNode, EditableTableNodeProps } from '@/components/molecules/EditableTableNode'
+import { NoteNode, NoteNodeProps } from '@/components/molecules/NoteNode'
+import { EditToolbar } from '@/components/organisms/EditToolbar'
+import { CanvasActions } from '@/components/organisms/CanvasActions'
+import { deserializeDesign, DesignSnapshot } from '@/lib/design'
 
 interface QueryParams {
   dashboardId?: string
@@ -74,6 +79,8 @@ export const Cl = () => {
   const setShowColumn = useStoreZustand((state) => state.setShowColumn)
   const truncated = useStoreZustand((state) => state.truncated)
   const setTruncated = useStoreZustand((state) => state.setTruncated)
+  const setSourceMode = useStoreZustand((state) => state.setSourceMode)
+  const editMode = useStoreZustand((state) => state.editMode)
 
   const searchParams = useSearchParams()
 
@@ -133,7 +140,15 @@ export const Cl = () => {
 
   const onNodesChange = useCallback(
     (changes: NodeChange[]) =>
-      setNodes((nds) => applyNodeChanges(changes, nds)),
+      setNodes((nds) => {
+        const next = applyNodeChanges(changes, nds)
+        // ドラッグで動かされたノードは data.manual を立て、以降の再レイアウトで戻らないようにする
+        const movedIds = new Set(
+          changes.filter((c): c is NodeChange & { id: string } => c.type === 'position').map((c) => c.id),
+        )
+        if (movedIds.size === 0) return next
+        return next.map((n) => (movedIds.has(n.id) ? { ...n, data: { ...n.data, manual: true } } : n))
+      }),
     [setNodes],
   )
   const onEdgesChange = useCallback(
@@ -141,14 +156,30 @@ export const Cl = () => {
       setEdges((eds) => applyEdgeChanges(changes, eds)),
     [setEdges],
   )
+  // ユーザーが手で引いた線には data.custom を刻印し、マージ保護・区別描画の起点にする
   const onConnect = useCallback(
-    (connection: Connection) => setEdges((eds) => addEdge(connection, eds)),
+    (connection: Connection) =>
+      setEdges((eds) => addEdge({ ...connection, data: { custom: true }, style: { stroke: '#7c3aed', strokeDasharray: '6 4' } }, eds)),
     [setEdges],
   )
 
+  // スナップショット(URL/Import)を適用する。全ノードを manual 扱いにして dagre の再配置を抑止し、
+  // 凍結した位置をそのまま再現する。setNodesPositioned(false) は fitView のトリガー。
+  const applySnapshot = useCallback((snapshot: DesignSnapshot) => {
+    setShowColumn(snapshot.view.showColumn)
+    setOptions({ rankdir: snapshot.view.rankdir })
+    setSourceMode(snapshot.view.sourceMode)
+    setNodes(snapshot.nodes.map((n) => ({ ...n, data: { ...n.data, manual: true } })))
+    setEdges(snapshot.edges)
+    setTruncated(false)
+    setNodesPositioned(false)
+  }, [setShowColumn, setOptions, setSourceMode, setNodes, setEdges, setTruncated])
+
   const nodeTypes = useMemo(() => ({
     tableNode: (props: TableNodeProps) => <TableNode {...props} />,
-    dashboardNode: (props: DashboardNodeProps) => <DashboardNode {...props} />
+    dashboardNode: (props: DashboardNodeProps) => <DashboardNode {...props} />,
+    editableTableNode: (props: EditableTableNodeProps) => <EditableTableNode {...props} />,
+    noteNode: (props: NoteNodeProps) => <NoteNode {...props} />,
   }), [])
 
   // 外部から setRefreshNodesPosition が呼ばれた場合
@@ -170,6 +201,21 @@ export const Cl = () => {
   useEffect(() => {
     setOptions({ rankdir: 'RL' })
   }, [setOptions])
+
+  // URL に ?design=... があればスナップショットを復元する。マウント時に1回だけ実行する。
+  /* eslint-disable react-hooks/exhaustive-deps, react-hooks/set-state-in-effect */
+  useEffect(() => {
+    const encoded = searchParams.get('design')
+    if (!encoded) return
+    const snapshot = deserializeDesign(encoded)
+    if (snapshot) {
+      applySnapshot(snapshot)
+    } else {
+      setMessage('Invalid or corrupted design URL', 'error')
+      setTimeout(() => setMessage(null, null), 3000)
+    }
+  }, [])
+  /* eslint-enable react-hooks/exhaustive-deps, react-hooks/set-state-in-effect */
 
   return (
     <div>
@@ -194,7 +240,11 @@ export const Cl = () => {
               onEdgesChange={onEdgesChange}
               onConnect={onConnect}
               nodeTypes={nodeTypes}
+              nodesConnectable={editMode}
             >
+              <Panel position="top-center">
+                <EditToolbar nodes={nodes} edges={edges} setNodes={setNodes} applySnapshot={applySnapshot} />
+              </Panel>
               {truncated && (
                 <Panel position="top-center">
                   <div
@@ -253,6 +303,17 @@ export const Cl = () => {
                   </div>
                 </div>
                 }
+              </Panel>
+              {editMode && (
+                <Panel position="bottom-left" style={{ marginLeft: 50, marginBottom: 15 }}>
+                  <span className="flex items-center gap-1.5 rounded-full bg-violet-600 px-2.5 py-1 text-[10px] font-semibold tracking-wide text-white shadow-md">
+                    <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-white" />
+                    EDIT MODE
+                  </span>
+                </Panel>
+              )}
+              <Panel position="bottom-right" style={{ marginBottom: 28 }}>
+                <CanvasActions />
               </Panel>
               <Controls />
               <Background style={{ backgroundColor: '#f5f5f5' }} />

--- a/frontend/src/components/pages/Cl.tsx
+++ b/frontend/src/components/pages/Cl.tsx
@@ -305,7 +305,7 @@ export const Cl = () => {
                 }
               </Panel>
               {editMode && (
-                <Panel position="bottom-center">
+                <Panel position="bottom-center" style={{ marginBottom: 28 }}>
                   <span className="flex items-center gap-1.5 rounded-full bg-violet-600 px-2.5 py-1 text-[10px] font-semibold tracking-wide text-white shadow-md">
                     <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-white" />
                     EDIT MODE

--- a/frontend/src/components/pages/Cl.tsx
+++ b/frontend/src/components/pages/Cl.tsx
@@ -305,7 +305,7 @@ export const Cl = () => {
                 }
               </Panel>
               {editMode && (
-                <Panel position="bottom-left" style={{ marginLeft: 50, marginBottom: 15 }}>
+                <Panel position="bottom-center">
                   <span className="flex items-center gap-1.5 rounded-full bg-violet-600 px-2.5 py-1 text-[10px] font-semibold tracking-wide text-white shadow-md">
                     <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-white" />
                     EDIT MODE

--- a/frontend/src/components/ui/SchemaSourceColumnSelect.tsx
+++ b/frontend/src/components/ui/SchemaSourceColumnSelect.tsx
@@ -186,6 +186,10 @@ export const SchemaSourceColumnSelect: React.FC<HeaderProps> = ({handleFetchData
   // submit/handleFetch* を deps に入れると毎レンダー再取得・再送信になるため意図的に空配列にしている。
   /* eslint-disable react-hooks/exhaustive-deps, react-hooks/set-state-in-effect */
   useEffect(() => {
+    // ?design=... での復元時は Cl 側がスナップショットを適用するため、ここでリネージを引き直さない
+    if (searchParams.has('design')) {
+      return
+    }
     if (searchParams.size) {
       submit(true)
     } else {

--- a/frontend/src/components/ui/ToggleButtons.tsx
+++ b/frontend/src/components/ui/ToggleButtons.tsx
@@ -1,19 +1,17 @@
 import React, { useCallback, useEffect, useState } from 'react'
 import { useStore as useStoreZustand } from '@/store/zustand'
 import { Edge, useReactFlow } from '@xyflow/react'
-import { toBlob } from 'html-to-image'
-import { Camera, Table, Columns3 } from 'lucide-react'
+import { Table, Columns3 } from 'lucide-react'
 
 const ToggleButtons = () => {
   const { getEdges, setEdges } = useReactFlow()
-  const { fitView } = useReactFlow()
   const showColumn = useStoreZustand((state) => state.showColumn)
   const setShowColumn = useStoreZustand((state) => state.setShowColumn)
   const setClearNodePosition = useStoreZustand((state) => state.setClearNodePosition)
   const columnModeEdges = useStoreZustand((state) => state.columnModeEdges)
   const setColumnModeEdges = useStoreZustand((state) => state.setColumnModeEdges)
   const setRightMaxDepth = useStoreZustand((state) => state.setRightMaxDepth)
-  const setMessage = useStoreZustand((state) => state.setMessage)
+  const editMode = useStoreZustand((state) => state.editMode)
 
   const [activeButton, setActiveButton] = useState('column')
 
@@ -82,63 +80,33 @@ const ToggleButtons = () => {
     setClearNodePosition(true)
   }, [getEdges, setEdges, setShowColumn, setClearNodePosition, columnModeEdges, setColumnModeEdges, setRightMaxDepth])
 
-  const copyToClipboard = useCallback(async() => {
-    const flowElement = document.querySelector('.react-flow__viewport') as HTMLElement
-
-    // ビューをフィットさせる
-    window.requestAnimationFrame(() => fitView())
-    await new Promise(resolve => setTimeout(resolve, 100))
-    const blob = await toBlob(flowElement, { backgroundColor: '#fff', })
-    if (blob) {
-      try {
-        let data = [new window.ClipboardItem({ 'image/png': blob })]
-        await navigator.clipboard.write(data)
-        const params = new URLSearchParams(window.location.search).toString()
-        setMessage('Successfully copied to clipboard!:\n\n' + params, 'success')
-        setTimeout(() => setMessage(null, null), 6000) // Clear message after 3 seconds
-      } catch (err) {
-        setMessage('Failed to copy to clipboard', 'error')
-        console.error('Failed to copy:', err)
-        setTimeout(() => setMessage(null, null), 3000) // Clear message after 3 seconds
-      }
+  // 編集はカラム名を扱うので、編集に入るとき(editMode が true 化)で Table 表示なら Column へ自動切替する。
+  // editMode の遷移時だけ反応させたいので deps は editMode のみ(handleToggleButton/showColumn は意図的に除外)。
+  /* eslint-disable react-hooks/exhaustive-deps */
+  useEffect(() => {
+    if (editMode && !showColumn) {
+      handleToggleButton('column')
     }
-  }, [fitView, setMessage])
+  }, [editMode])
+  /* eslint-enable react-hooks/exhaustive-deps */
 
   return (
-    <div className="flex flex-col space-y-4">
-      <div className="flex items-center space-x-4">
-        <div className="inline-flex rounded-md shadow-xs" role="group">
-          {buttons.map((button) => (
-            <button
-              key={button.id}
-              type="button"
-              className={`px-4 py-2 text-sm font-medium border flex items-center whitespace-nowrap ${
-                activeButton === button.id
-                  ? 'bg-blue-500 text-white border-blue-600'
-                  : 'bg-white text-gray-700 border-gray-200 hover:bg-gray-50'
-              } ${
-                button.id === buttons[0].id
-                  ? 'rounded-l-lg'
-                  : button.id === buttons[buttons.length - 1].id
-                    ? 'rounded-r-lg'
-                    : ''
-              }`}
-              onClick={() => handleToggleButton(button.id)}
-            >
-              <button.icon className="mr-2" size={16} />
-              <span>{button.label}</span>
-            </button>
-          ))}
-        </div>
+    <div className="inline-flex w-fit self-start overflow-hidden rounded-lg border border-gray-200 shadow-md" role="group">
+      {buttons.map((button) => (
         <button
-          onClick={copyToClipboard}
-          className="rounded-sm px-4 py-2 text-sm font-medium border bg-blue-500 text-white border-blue-600 flex items-center hover:bg-blue-600 transition-colors duration-200"
-          aria-label="Copy to clipboard"
+          key={button.id}
+          type="button"
+          className={`px-2.5 py-1.5 text-xs font-medium flex items-center whitespace-nowrap ${
+            activeButton === button.id
+              ? 'bg-blue-500 text-white'
+              : 'bg-white text-gray-700 hover:bg-gray-50'
+          }`}
+          onClick={() => handleToggleButton(button.id)}
         >
-          <Camera className="mr-2" size={16} />
-          <span>Copy to clipboard</span>
+          <button.icon className="mr-1" size={15} />
+          <span>{button.label}</span>
         </button>
-      </div>
+      ))}
     </div>
   )
 }

--- a/frontend/src/components/ui/ToggleButtons.tsx
+++ b/frontend/src/components/ui/ToggleButtons.tsx
@@ -91,7 +91,7 @@ const ToggleButtons = () => {
   /* eslint-enable react-hooks/exhaustive-deps */
 
   return (
-    <div className="inline-flex w-fit self-start overflow-hidden rounded-lg border border-gray-200 shadow-md" role="group">
+    <div className="inline-flex w-fit self-start overflow-hidden rounded-lg border border-gray-200" role="group">
       {buttons.map((button) => (
         <button
           key={button.id}

--- a/frontend/src/components/ui/Tooltip.tsx
+++ b/frontend/src/components/ui/Tooltip.tsx
@@ -1,0 +1,33 @@
+'use client'
+import React from 'react'
+
+type Side = 'top' | 'bottom' | 'left' | 'right'
+
+const sidePos: Record<Side, string> = {
+  top: 'bottom-full left-1/2 -translate-x-1/2 mb-1.5',
+  bottom: 'top-full left-1/2 -translate-x-1/2 mt-1.5',
+  left: 'right-full top-1/2 -translate-y-1/2 mr-1.5',
+  right: 'left-full top-1/2 -translate-y-1/2 ml-1.5',
+}
+
+// ホバーで即表示する軽量ツールチップ(CSS group-hover、依存追加なし)。
+// children は単一のトリガー要素(ボタン等)を想定。aria-label は呼び出し側に任せる。
+export const Tooltip = ({
+  label,
+  side = 'bottom',
+  children,
+}: {
+  label: string
+  side?: Side
+  children: React.ReactNode
+}) => (
+  <span className="group/tt relative inline-flex">
+    {children}
+    <span
+      role="tooltip"
+      className={`pointer-events-none absolute z-50 whitespace-nowrap rounded bg-gray-800 px-2 py-1 text-[11px] font-medium text-white opacity-0 shadow-md transition-opacity duration-150 group-hover/tt:opacity-100 ${sidePos[side]}`}
+    >
+      {label}
+    </span>
+  </span>
+)

--- a/frontend/src/hooks/useEventNodeOperations.ts
+++ b/frontend/src/hooks/useEventNodeOperations.ts
@@ -186,7 +186,9 @@ export const useEventNodeOperations = (id: string) => {
     const nodesWithMultipleConnections = identifyNodesWithMultipleConnections(edges)
 
     const walk = (id: string): string[] => {
-      const childEdges = edges.filter(edge => edge.source === id)
+      // ユーザーが手で引いた線(data.custom)は辿らない。生成リネージを畳んでも
+      // 設計ノード/コメントが巻き込まれて消えないようにするため。
+      const childEdges = edges.filter(edge => edge.source === id && !(edge.data as { custom?: boolean } | undefined)?.custom)
       const childNodeIds = childEdges.map(edge => edge.target)
 
       const newChildNodeIds = childNodeIds.filter(childId => {

--- a/frontend/src/lib/design.ts
+++ b/frontend/src/lib/design.ts
@@ -1,0 +1,102 @@
+import { Edge, Node } from '@xyflow/react'
+import LZString from 'lz-string'
+import { SourceModeType } from '@/store/zustand'
+
+// 設計図(DFD)スナップショットの形。グラフだけでなくビューモード状態も含める。
+// tableNode の描画(列ハンドルの有無/位置)は showColumn・rankdir に依存し、
+// これらが復元時に一致していないとエッジの参照先ハンドルが存在せず図が壊れるため。
+export interface DesignView {
+  showColumn: boolean
+  rankdir: string
+  sourceMode: SourceModeType
+}
+
+export interface DesignSnapshot {
+  v: number
+  view: DesignView
+  nodes: Node[]
+  edges: Edge[]
+}
+
+const SNAPSHOT_VERSION = 1
+
+// シリアライズ対象のフィールドだけ抽出して軽量化する(transient な計測値などは落とす)
+const pickNode = (node: Node): Node => ({
+  id: node.id,
+  type: node.type,
+  position: node.position,
+  data: node.data,
+  ...(node.width ? { width: node.width } : {}),
+  ...(node.height ? { height: node.height } : {}),
+}) as Node
+
+const pickEdge = (edge: Edge): Edge => ({
+  id: edge.id,
+  source: edge.source,
+  target: edge.target,
+  ...(edge.sourceHandle ? { sourceHandle: edge.sourceHandle } : {}),
+  ...(edge.targetHandle ? { targetHandle: edge.targetHandle } : {}),
+  ...(edge.type ? { type: edge.type } : {}),
+  ...(edge.data ? { data: edge.data } : {}),
+  ...(edge.style ? { style: edge.style } : {}),
+}) as Edge
+
+// 素の JSON スナップショットを作る(Export/Import 用にも共有)
+export const buildSnapshot = (nodes: Node[], edges: Edge[], view: DesignView): DesignSnapshot => ({
+  v: SNAPSHOT_VERSION,
+  view,
+  nodes: nodes.map(pickNode),
+  edges: edges.map(pickEdge),
+})
+
+// 形状ガード。壊れた共有 URL / 不正な JSON でも null を返して落とさない。
+const isValidSnapshot = (obj: unknown): obj is DesignSnapshot => {
+  if (!obj || typeof obj !== 'object') return false
+  const o = obj as Record<string, unknown>
+  return (
+    Array.isArray(o.nodes) &&
+    Array.isArray(o.edges) &&
+    !!o.view &&
+    typeof o.view === 'object'
+  )
+}
+
+const normalizeView = (view: Partial<DesignView> | undefined): DesignView => ({
+  showColumn: view?.showColumn ?? true,
+  rankdir: view?.rankdir ?? 'RL',
+  sourceMode: view?.sourceMode ?? 'dbt',
+})
+
+// URL 用: 圧縮して encodeURIComponent 安全な文字列にする
+export const serializeDesign = (nodes: Node[], edges: Edge[], view: DesignView): string => {
+  const snapshot = buildSnapshot(nodes, edges, view)
+  return LZString.compressToEncodedURIComponent(JSON.stringify(snapshot))
+}
+
+export const deserializeDesign = (encoded: string): DesignSnapshot | null => {
+  try {
+    const json = LZString.decompressFromEncodedURIComponent(encoded)
+    if (!json) return null
+    const parsed = JSON.parse(json)
+    if (!isValidSnapshot(parsed)) return null
+    return { ...parsed, view: normalizeView(parsed.view) }
+  } catch (e) {
+    console.error('Failed to deserialize design:', e)
+    return null
+  }
+}
+
+// Export/Import 用: 整形した素の JSON 文字列
+export const exportDesignJson = (nodes: Node[], edges: Edge[], view: DesignView): string =>
+  JSON.stringify(buildSnapshot(nodes, edges, view), null, 2)
+
+export const importDesignJson = (text: string): DesignSnapshot | null => {
+  try {
+    const parsed = JSON.parse(text)
+    if (!isValidSnapshot(parsed)) return null
+    return { ...parsed, view: normalizeView(parsed.view) }
+  } catch (e) {
+    console.error('Failed to import design JSON:', e)
+    return null
+  }
+}

--- a/frontend/src/store/zustand.ts
+++ b/frontend/src/store/zustand.ts
@@ -20,6 +20,7 @@ type State = {
   isSubmitDisabled: boolean
   headerSearchDisplayMessage: string
   truncated: boolean
+  editMode: boolean
 }
 
 type Action = {
@@ -38,6 +39,7 @@ type Action = {
   setIsSubmitDisabled: (v: boolean) => void
   setHeaderSearchDisplayMessage: (v: string) => void
   setTruncated: (v: boolean) => void
+  setEditMode: (v: boolean) => void
 }
 
 export const useStore = create<State & Action>()((set) => ({
@@ -56,6 +58,7 @@ export const useStore = create<State & Action>()((set) => ({
   isSubmitDisabled: false,
   headerSearchDisplayMessage: 'Select search model',
   truncated: false,
+  editMode: false,
   setOptions: (v:any) => set({options: v}),
   setShowColumn: (v:boolean) => set({showColumn: v}),
   setSidebarActive: (v:boolean) => set({sidebarActive: v}),
@@ -71,4 +74,5 @@ export const useStore = create<State & Action>()((set) => ({
   setIsSubmitDisabled: (v: boolean) => set({ isSubmitDisabled: v }),
   setHeaderSearchDisplayMessage: (v: string) => set({ headerSearchDisplayMessage: v }),
   setTruncated: (v: boolean) => set({ truncated: v }),
+  setEditMode: (v: boolean) => set({ editMode: v }),
 }))

--- a/src/dbt_column_lineage/lineage.py
+++ b/src/dbt_column_lineage/lineage.py
@@ -28,10 +28,10 @@ class DbtSqlglot:
         self.edges = []
         self.target_dashboard_ids = []
         self.request_depth = request_depth
-        # depth 上限(request_depth)で実際に系統を打ち切ったか。未探索の依存が
-        # 残ったまま深さ制限で止まった場合のみ True(自然に末端へ達した場合は False)。
-        # 時間予算/ノード数上限による打ち切りでも True を立てる(フロントのバナーは共通)。
-        self.depth_truncated = False
+        # 時間予算(MAX_LINEAGE_SECONDS)による打ち切りが起きたか。フロントの truncated バナーは
+        # この“想定外の保護打ち切り”専用。要求 depth に達して止まるのは設計どおりなので含めない
+        # (depth=1 のテーブル表示で毎回バナーが出てしまう問題を避ける)。
+        self.budget_truncated = False
         # 時間予算の締切(MAX_LINEAGE_SECONDS>0 のときだけ。それ以外は None=無制限)。
         self._deadline = (time.monotonic() + MAX_LINEAGE_SECONDS) if MAX_LINEAGE_SECONDS and MAX_LINEAGE_SECONDS > 0 else None
 
@@ -158,13 +158,13 @@ class DbtSqlglot:
 
 
     def ret_edges_nodes(self) -> dict:
-        return {'edges': self.edges, 'nodes': self.nodes, 'truncated': self.depth_truncated}
+        return {'edges': self.edges, 'nodes': self.nodes, 'truncated': self.budget_truncated}
 
     def _budget_exceeded(self) -> bool:
         """時間予算(MAX_LINEAGE_SECONDS)を超えていれば打ち切りフラグを立てて True。
         コストが横幅(ハブ列の全下流など)の場合に、形状に依らず処理を止める保護。"""
         if self._deadline is not None and time.monotonic() > self._deadline:
-            self.depth_truncated = True
+            self.budget_truncated = True
             return True
         return False
 
@@ -614,9 +614,7 @@ class DbtSqlglot:
         depth = depth + 1
         if self.request_depth != -1 and depth > self.request_depth:
             self.logger.info(f'depth={depth} reached')
-            # 未探索の依存が残っているなら、深さ上限で打ち切った
-            if deps_refs:
-                self.depth_truncated = True
+            # 要求 depth に達して止まるのは設計どおり。バナー(budget_truncated)は立てない。
             return
 
         for deps_unique_id in deps_refs:
@@ -700,9 +698,7 @@ class DbtSqlglot:
         next_found = False
         for after_base_column, after_next_sources_columns in after_next_sources_columns_dict.items():
             if self.request_depth != -1 and depth > self.request_depth:
-                # まだ辿るべき上流/下流(labels)があるのに深さ上限で止めた = 打ち切り
-                if after_next_sources_columns.get('labels'):
-                    self.depth_truncated = True
+                # 要求 depth に達して止まるのは設計どおり。バナー(budget_truncated)は立てない。
                 continue
             after_next_sources = after_next_sources_columns['labels']
             after_next_columns = after_next_sources_columns['columns']


### PR DESCRIPTION
## 概要
データ調査だけでなく**設計フェーズ**を支えるため、開発者がリネージ上に**自分のテーブル・カラム(PK可)・ノート・エッジをプロット**でき、それを **URL / JSON のスナップショットで再現**できる「編集モード」を追加します。プロットした図は設計成果物の DFD として活用できます。

## 主な変更

### フロントエンド
- **編集モード**（zustand）: 右下の鉛筆 FAB でトグル（ON で紫）。左下に `EDIT MODE` バッジで状態表示。
- **上部中央フローティングバー**: `Table` / `Note` 追加・`Share URL` / `Export` / `Import`。「作る」「保存・共有」を区切り線で分け、ホバーで切り替わる説明エリア（起動直後だけ既定ヒント、数秒で消える）。
- **EditableTableNode**（テーブル名＋カラム＋複合PK）/ **NoteNode**（付箋）。手で引いた線は `data.custom` を刻印。実テーブルと同じ `${column}__source/__target` ハンドル規約でエッジが整合・再現。
- **スナップショット**（`lib/design.ts`, lz-string）: グラフ＋ビュー状態(showColumn/rankdir/sourceMode)を保存。`?design=...` で **API を引かずに**復元。Share URL はサイズガード付き（>2KB 警告 / >8KB はブロックして Export 誘導）。
- **dagre**: 再現性を壊していた `Math.random()` ジッタを除去、`data.manual` ノードは再配置をスキップ。マージ/非表示処理はカスタム要素を保持。
- 再利用可能な **Tooltip**、浮くコントロールの影を `shadow-md` に統一。

### バックエンド
- `truncated` バナーを**時間バジェット専用**（`budget_truncated`）に分離。要求 depth に達して止まるケース（テーブルモード depth=1 等）ではフラグを立てない → **意図的な初期表示で毎回バナーが出る問題を解消**。

### ドキュメント
- `CLAUDE.md` に **`.venv` での pytest 手順**を追記（system python には sqlglot が無く collection エラーになるため）。

## 検証
- `npm run lint` 0 warnings / `tsc --noEmit` OK / `next build` 成功
- `.venv/bin/python -m pytest test/unit` → **27 passed**
- ブラウザ実走: ノード/Note 追加・カラム間ドラッグ接続・PK(複合)・`?design` 復元(API非依存)・Share URL サイズガード・Export/Import・ツールチップ/操作ヒント・各種レイアウトをエラー0で確認

## 補足
- `.envrc`（機密）は変更・コミットしていません。本番の `MAX_LINEAGE_SECONDS` 等は従来どおりデプロイ環境側で管理。

🤖 Generated with [Claude Code](https://claude.com/claude-code)