### PR TITLE
chore: OSS-readiness — deps, LICENSE, CI, community docs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,41 @@
+---
+name: Bug report
+about: Something isn't working as expected
+title: "[bug] "
+labels: bug
+---
+
+## Description
+
+<!-- A clear description of the bug. -->
+
+## To reproduce
+
+Steps to reproduce, ideally with the model/column involved:
+
+1.
+2.
+
+## Expected vs actual
+
+- **Expected:**
+- **Actual:**
+
+## Environment
+
+- `dbt-column-lineage` version:
+- Install method: `pip` / Docker / from source
+- `SQLGLOT_DIALECT` (warehouse):
+- Python version:
+- Browser (for UI issues):
+
+## Lineage context (if relevant)
+
+- Table / column queried:
+- Table-level or column-level? Reverse?
+- Anything unusual in the model SQL (UNPIVOT, lateral, recursive CTE, etc.)?
+
+## Logs / screenshots
+
+<!-- Backend logs (run with DEBUG_MODE=true), console errors, or screenshots.
+     Do NOT paste secrets. -->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/tomoki-takahashi-oisix/dbt-column-lineage/security/advisories/new
+    about: Please report security issues privately, not as a public issue (see SECURITY.md).

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,22 @@
+---
+name: Feature request
+about: Suggest an idea or improvement
+title: "[feat] "
+labels: enhancement
+---
+
+## Problem / motivation
+
+<!-- What are you trying to do, and where does the tool fall short today? -->
+
+## Proposed solution
+
+<!-- What would you like to happen? -->
+
+## Alternatives considered
+
+<!-- Other approaches you've thought about, if any. -->
+
+## Additional context
+
+<!-- Mockups, example projects, related issues, etc. -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,17 @@
+<!-- Thanks for contributing! Keep PRs focused; describe the *why*. -->
+
+## What & why
+
+<!-- What does this change and what problem does it solve? -->
+
+## How tested
+
+<!-- e.g. `pytest test/unit -q`, `cd frontend && npm run lint && npm run build`,
+     or manual steps in the app. -->
+
+## Checklist
+
+- [ ] `pytest test/unit -q` passes
+- [ ] `cd frontend && npm run lint && npm run build` pass (0 lint warnings)
+- [ ] Updated `CHANGELOG.md` (`[Unreleased]`) for user-facing changes
+- [ ] Updated docs (`README.md` / `CLAUDE.md`) if behavior or setup changed

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,44 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  backend:
+    name: backend (pytest)
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.11", "3.12"]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # setuptools_scm needs tags to derive the version
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+      # Installing the package itself also validates that [project.dependencies]
+      # is complete and resolvable.
+      - run: pip install -e ".[dev]"
+      - run: pytest test/unit -q
+
+  frontend:
+    name: frontend (lint + build)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+      - run: npm ci
+      - run: npm run lint
+      - run: npm run build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,30 @@
+# Changelog
+
+All notable changes to this project are documented here.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+Versions are derived from git tags via `setuptools_scm`; see the
+[releases](https://github.com/tomoki-takahashi-oisix/dbt-column-lineage/releases)
+and [git tags](https://github.com/tomoki-takahashi-oisix/dbt-column-lineage/tags)
+for the full history prior to this file.
+
+## [Unreleased]
+
+### Fixed
+- **Packaging: declare runtime dependencies.** `sqlglot`, `fastapi`, `uvicorn`,
+  `requests`, `pytz`, `itsdangerous`, and `typer` are now listed in
+  `[project.dependencies]`. Previously they lived only in `requirements.txt`, so
+  `pip install dbt-column-lineage` installed the package without its
+  dependencies. **Upgrade strongly recommended.**
+
+### Added
+- `LICENSE` file (MIT) — the license was declared in metadata but the text was
+  missing.
+- `looker` optional extra for `looker-sdk` (only needed to run the offline
+  `tools/looker_analyzer.py`; the runtime never calls the SDK).
+- Project metadata: richer `description`, `keywords`, and `Homepage`/`Issues`/
+  `Changelog` URLs.
+- GitHub Actions CI: backend tests (Python 3.11/3.12) + frontend lint/build.
+- Community docs: `CONTRIBUTING.md`, `SECURITY.md`, `CODE_OF_CONDUCT.md`, issue
+  and pull-request templates.
+- README demo GIF and a synthetic, warehouse-free demo project under `demo/`.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,85 @@
+
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at takahashi_tomoki@oisixradaichi.co.jp. All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at [https://www.contributor-covenant.org/faq][FAQ]. Translations are available at [https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,64 @@
+# Contributing
+
+Thanks for your interest in improving **dbt-column-lineage**! This guide covers
+the local setup, the checks we run, and how to propose changes.
+
+## Development setup
+
+The backend (FastAPI/uvicorn) and frontend (Next.js) run as separate dev servers.
+
+```bash
+# Backend — port 5000, from the repo root
+python3 -m venv .venv && source .venv/bin/activate
+pip install -e ".[dev]"          # runtime + test deps
+uvicorn --app-dir src dbt_column_lineage.main:app --port=5000 --reload
+
+# Frontend — port 3000, from frontend/
+cd frontend
+npm install
+NEXT_PUBLIC_API_HOSTNAME=http://localhost:5000 npm run dev
+```
+
+You need a dbt project with `target/manifest.json` and `target/catalog.json`
+(`dbt docs generate`). Point the backend at it via `DBT_PROJECT_DIR`, and set
+`SQLGLOT_DIALECT` to match your warehouse (default `snowflake`).
+
+No warehouse handy? The repo ships a synthetic project under [`demo/`](demo/):
+
+```bash
+python demo/build_demo_manifest.py
+DBT_PROJECT_DIR="$PWD/demo/dbt_project" SQLGLOT_DIALECT=snowflake \
+  uvicorn --app-dir src dbt_column_lineage.main:app --port=5000
+```
+
+## Checks (please run before opening a PR)
+
+```bash
+# Backend tests (27+; see pyproject testpaths)
+pytest test/unit -q
+
+# Frontend lint — baseline is 0 warnings — and build
+cd frontend && npm run lint && npm run build
+```
+
+CI (`.github/workflows/ci.yml`) runs the same on every PR (Python 3.11/3.12 +
+Node 20).
+
+## Pull requests
+
+- Branch from `main`; open the PR against `main`.
+- Keep changes focused and describe the *why*, not just the *what*.
+- Update `CHANGELOG.md` (the `[Unreleased]` section) for user-facing changes.
+- Match the surrounding code style. Python is formatted with `black`/`isort`;
+  the frontend follows the ESLint flat config.
+
+## Releasing (maintainers)
+
+Releases are cut with `just pypi <version>` — it rebuilds the frontend, tags
+`v<version>`, builds the sdist/wheel, and uploads to PyPI. The version is
+derived from the git tag via `setuptools_scm`.
+
+## Reporting bugs / requesting features
+
+Use the issue templates. For security issues, **do not** open a public issue —
+see [SECURITY.md](SECURITY.md).

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024-2026 Tomoki Takahashi
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,31 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+Please **do not** open a public GitHub issue for security vulnerabilities.
+
+Instead, report privately via one of:
+
+- GitHub's [private vulnerability reporting](https://github.com/tomoki-takahashi-oisix/dbt-column-lineage/security/advisories/new)
+  (Security → Report a vulnerability), or
+- email **takahashi_tomoki@oisixradaichi.co.jp**.
+
+Please include reproduction steps and the affected version. We aim to
+acknowledge reports within a few business days.
+
+## Supported versions
+
+This project follows a rolling release model: only the **latest** version
+published on PyPI is supported. Please upgrade before reporting.
+
+## Notes for operators
+
+- **Credentials are never committed.** `.envrc` is gitignored; keep OAuth
+  (`GOOGLE_CLIENT_*`), `SESSION_SECRET`, and Looker SDK secrets out of the repo
+  and out of logs. In hosted deployments, inject them via your platform's secret
+  manager.
+- **`SESSION_SECRET`** must be a fixed value when `USE_OAUTH=true` and you run
+  more than one process/instance, or signed-cookie sessions break across
+  processes. See the README and `CLAUDE.md` for details.
+- The app trusts the dbt artifacts (`manifest.json`/`catalog.json`) and
+  `compiled_code` it parses. Only point it at projects you trust.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,10 +5,20 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "dbt_column_lineage"
 dynamic = ["version"]
-description = "A tool for dbt column lineage"
+description = "Visualize column-level lineage of dbt models in the browser, parsed from manifest.json/catalog.json with sqlglot"
 authors = [{name = "Tomoki Takahashi", email = "takahashi_tomoki@oisixradaichi.co.jp"}]
 readme = "README.md"
 requires-python = ">=3.11"
+keywords = ["dbt", "lineage", "column-lineage", "sqlglot", "data-lineage", "snowflake"]
+dependencies = [
+    "sqlglot>=30,<31",
+    "fastapi>=0.115",
+    "uvicorn>=0.30",
+    "requests>=2.31",
+    "pytz>=2024.1",
+    "itsdangerous>=2.1",
+    "typer>=0.12",
+]
 classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
@@ -17,6 +27,9 @@ classifiers = [
 ]
 
 [project.optional-dependencies]
+# looker-sdk is only needed to run tools/looker_analyzer.py (offline analysis);
+# the published runtime reads target/looker_analysis.json and never calls the SDK.
+looker = ["looker-sdk>=24.0"]
 dev = [
     "pytest",
     "black",
@@ -27,7 +40,10 @@ dev = [
 dbt-column-lineage = "dbt_column_lineage.main:main"
 
 [project.urls]
+Homepage = "https://github.com/tomoki-takahashi-oisix/dbt-column-lineage"
 Repository = "https://github.com/tomoki-takahashi-oisix/dbt-column-lineage"
+Issues = "https://github.com/tomoki-takahashi-oisix/dbt-column-lineage/issues"
+Changelog = "https://github.com/tomoki-takahashi-oisix/dbt-column-lineage/blob/main/CHANGELOG.md"
 
 [tool.setuptools.packages.find]
 where = ["src"]


### PR DESCRIPTION
`just pypi` で公開する前提でOSSとしての不足を棚卸しし、まとめて整備した。

## 🔴 リリースブロッカー修正

### 1. ランタイム依存が公開パッケージに無かった（最重要）
依存が `requirements.txt` にしか無く `[project.dependencies]` 未宣言だったため、`pip install dbt-column-lineage` が**依存ゼロでインストール**されていた（公開済み 0.5.26 の `requires_dist` は dev extra のみ）。

→ `sqlglot / fastapi / uvicorn / requests / pytz / itsdangerous / typer` を宣言。**ビルドしたwheelの `Requires-Dist` に7件全て入ることを検証済み。**

### 2. LICENSE ファイルが無かった
classifier・バッジはMITなのに本文が不在＝ライセンス未付与状態だった。MIT の `LICENSE` を追加（`License-File: LICENSE` がwheelに同梱されることを確認）。

## その他

- `looker-sdk` を `looker` optional extra に分離（`tools/looker_analyzer.py` 専用。ランタイムはJSONを読むだけでSDK未使用）。
- メタデータ整備: `description` / `keywords` / `Homepage`・`Issues`・`Changelog` URL。
- **CI**(`.github/workflows/ci.yml`): backend pytest(3.11/3.12) + frontend lint/build。backendジョブはパッケージをインストールするので、上記の依存欠落が再発したらCIで落ちる。
- コミュニティ文書: `CONTRIBUTING` / `SECURITY` / `CODE_OF_CONDUCT`(Contributor Covenant 2.1) / `CHANGELOG` / Issue・PRテンプレート。

## 要確認

- **LICENSE の著作権者**を `Tomoki Takahashi`(individual)にした。会社(Oisix Ra Daichi)所有物なら法人名にすべき。
- 依存のバージョン下限は安全側に設定（`sqlglot` のみ correctness 配慮で `<31` 上限）。必要なら調整可。

🤖 Generated with [Claude Code](https://claude.com/claude-code)