### PR TITLE
fix(cl): clean up the copy-as-image toast

### DIFF
--- a/frontend/src/components/organisms/CanvasActions.tsx
+++ b/frontend/src/components/organisms/CanvasActions.tsx
@@ -24,9 +24,8 @@ export const CanvasActions = () => {
       try {
         const data = [new window.ClipboardItem({ 'image/png': blob })]
         await navigator.clipboard.write(data)
-        const params = new URLSearchParams(window.location.search).toString()
-        setMessage('Successfully copied to clipboard!:\n\n' + params, 'success')
-        setTimeout(() => setMessage(null, null), 6000)
+        setMessage('Canvas image copied to clipboard!', 'success')
+        setTimeout(() => setMessage(null, null), 3000)
       } catch (err) {
         setMessage('Failed to copy to clipboard', 'error')
         console.error('Failed to copy:', err)


### PR DESCRIPTION
カメラFAB(Copy the canvas as an image)成功時の右上トーストが、メッセージに**URLのクエリ文字列を生で連結**していた（`selectedColumns` のURLエンコードJSON等がそのまま表示され、Markdownレンダリングで崩れがち）。

→ シンプルな確認文言 **「Canvas image copied to clipboard!」** に変更し、不要な params ダンプを削除。表示時間も他のトースト(3秒)に合わせた。

`npm run lint` 0警告。

> 補足: 「コピーした画像と一緒に再現用URLも出したい」意図だったなら、生クエリではなく整形したリンクとして出し直せます（要望あれば対応）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)