### PR TITLE
docs(changelog): cut 0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ for the full history prior to this file.
 
 ## [Unreleased]
 
+## [0.6.0] - 2026-06-11
+
+First release published with its runtime dependencies declared — earlier
+versions (0.5.x) install without them and are effectively broken; use 0.6.0+.
+
 ### Fixed
 - **Packaging: declare runtime dependencies.** `sqlglot`, `fastapi`, `uvicorn`,
   `requests`, `pytz`, `itsdangerous`, and `typer` are now listed in


### PR DESCRIPTION
0.6.0 を PyPI に公開したので、CHANGELOG の `[Unreleased]` を **`[0.6.0] - 2026-06-11`** に繰り上げ。0.5.x は依存なしで壊れている旨も明記。

公開確認:
- https://pypi.org/project/dbt-column-lineage/0.6.0/
- `requires_dist` に7依存反映済み
- クリーン環境で `pip install dbt-column-lineage==0.6.0` → 依存自動インストール・import OK を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)