### PR TITLE
docs(changelog): cut 0.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,15 @@ for the full history prior to this file.
 
 ## [Unreleased]
 
+## [0.6.1] - 2026-06-11
+
+### Changed
+- Home landing page: clearer hero copy ("Column-level lineage for dbt") with a
+  one-line value prop and an "Open the graph" CTA.
+
+### Fixed
+- Browser tab title typo: "dbt column linage" → "dbt column lineage".
+
 ## [0.6.0] - 2026-06-11
 
 First release published with its runtime dependencies declared — earlier


### PR DESCRIPTION
0.6.1 を PyPI 公開・GitHub Release 作成済みなので、CHANGELOG に `[0.6.1]`（hero copy / tab-title typo fix）を追加。

- https://pypi.org/project/dbt-column-lineage/0.6.1/
- https://github.com/tomoki-takahashi-oisix/dbt-column-lineage/releases/tag/v0.6.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)