### PR TITLE
Fix design Import overwrite; add UI guide with design-snapshot JSON spec

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,6 @@
 version: 2
 updates:
-  # Python backend (pyproject.toml / requirements.txt)
+  # Python backend (pyproject.toml)
   - package-ecosystem: pip
     directory: "/"
     schedule:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.11", "3.12"]
+        python-version: ["3.11", "3.12", "3.13", "3.14"]
     steps:
       - uses: actions/checkout@v4
         with:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ Backend and frontend run as separate dev servers.
 
 ```bash
 # Backend (port 5000) — from repo root, with venv activated
-pip install -r requirements.txt
+pip install -e ".[dev]"   # deps are declared only in pyproject.toml (no requirements.txt)
 uvicorn --app-dir src dbt_column_lineage.main:app --port=5000 --reload
 
 # Frontend (port 3000) — from frontend/

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,9 +12,13 @@ RUN npm run build
 FROM python:3.12 AS python-builder
 WORKDIR /app
 
-COPY ./requirements.txt .
+# 依存は pyproject.toml の [project.dependencies] が単一の情報源。
+# パッケージ本体は site-packages でなく /app/src から動かすため、依存だけを抽出して入れる
+# (この層は pyproject.toml が変わらない限りキャッシュされる)。
+# looker-sdk は tools/looker_analyzer.py(イメージ外で実行)専用なので入れない。
+COPY ./pyproject.toml .
 RUN pip install --upgrade pip && \
-    pip install --no-cache-dir -r requirements.txt
+    pip install --no-cache-dir $(python -c "import tomllib; print(' '.join(tomllib.load(open('pyproject.toml','rb'))['project']['dependencies']))")
 
 FROM python:3.12-slim-bookworm
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ python3 -m venv venv
 source venv/bin/activate
 
 pip install --upgrade pip
-pip install -r requirements.txt
+pip install -e ".[dev]"
 
 uvicorn --app-dir src dbt_column_lineage.main:app --port=5000 --reload
 ```

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ Trace a column across models, then expand more columns to grow the lineage inter
 
 There's also an **edit / design mode** (pencil button, bottom-right): edit existing models or sketch new ones — name, columns, and materialization type (table/view/incremental/snapshot/seed) — then share the design as a URL or export it as JSON.
 
+📖 See the **[UI guide](https://github.com/tomoki-takahashi-oisix/dbt-column-lineage/blob/main/docs/ui-guide.md)** for a tour of every operation — exploring the graph, the CTE page, edit / design mode, Looker mode, deep links, and the design-snapshot JSON spec for generating designs programmatically (e.g. from CI or an LLM agent).
+
 # quickstart
 Install dbt-column-lineage using pip:
 ```

--- a/docs/ui-guide.md
+++ b/docs/ui-guide.md
@@ -1,0 +1,226 @@
+# UI guide
+
+A tour of every operation in the dbt-column-lineage web UI: the lineage canvas (`/cl`), the CTE page (`/cte`), and edit / design mode.
+
+**Color language**: blue = analysis (lineage fetched from your dbt project), violet = design (things you draw yourself in edit mode).
+
+- [Pages](#pages)
+- [Choosing what to visualize](#choosing-what-to-visualize)
+- [Exploring the lineage graph (`/cl`)](#exploring-the-lineage-graph-cl)
+- [The CTE page (`/cte`)](#the-cte-page-cte)
+- [Edit / design mode](#edit--design-mode)
+- [Looker mode (optional)](#looker-mode-optional)
+- [Deep links](#deep-links)
+- [Design snapshot JSON — generating designs programmatically](#design-snapshot-json--generating-designs-programmatically)
+
+## Pages
+
+| Page | What it shows |
+|------|---------------|
+| `/cl` | Column-level (or table-level) lineage across models, as an interactive graph |
+| `/cte` | A single model broken down into its CTEs, side by side with the compiled SQL |
+
+Switch pages with the dropdown at the top-left of the header.
+
+## Choosing what to visualize
+
+Click the wide button in the header (it shows the current selection, e.g. `analytics | fct_orders`) to open the search dialog:
+
+1. **Table / Column** — pick the view mode. *Table* shows model-to-model lineage; *Column* traces individual columns through models.
+2. **Schema** — pick a schema.
+3. **Sources** — pick one or more models. On `/cl` you can select several; `/cte` takes exactly one.
+4. **Columns** (column mode only) — for each selected source (switch between them with the pills at the top right), pick the columns to trace.
+5. Press **Search**. The button stays disabled until the selection is complete (schema + source, plus at least one column in column mode).
+
+Defaults: column mode traces lineage to unlimited depth; table mode starts at depth 1 to keep wide graphs manageable — grow it from the nodes' **+** buttons instead.
+
+## Exploring the lineage graph (`/cl`)
+
+### Node anatomy
+
+Each model is a node whose header color encodes its materialization (see the legend at the top right: table / view / incremental / snapshot / seed).
+
+Header controls (hover the node):
+
+- **⋮ menu**
+  - **Copy table name** — copies the model name to the clipboard.
+  - **Open in dbt docs** — opens the model's page in your dbt docs site, in a new tab. Only present when the server has `DBT_DOCS_BASE_URL` set.
+  - **Edit (design)** — only in edit mode; converts the node into an editable design node (see below).
+- **✕ (Hide node)** — removes the node and its edges from the canvas. The node you originally searched for has no ✕.
+
+In **table mode** the table name is clickable and opens that model on the `/cte` page in a new tab. In **column mode**, each *column name* is clickable instead and opens `/cte` pre-focused on that column.
+
+### Growing and pruning the graph
+
+Lineage is explored incrementally from the **+** handles on each node:
+
+- **Left +** — fetch and append upstream parents (where the data comes from).
+- **Right +** — fetch and append downstream children (where the data goes).
+- Once expanded, the handle turns into **−**, which collapses that branch again.
+- A flat end-cap instead of a +/− means you've reached the end of the lineage in that direction.
+
+In column mode the handles sit on each column row, so you expand per column, not per table. To trace additional columns of a table that's already on the canvas, click the **chevron (⌄)** at the bottom of the node — it lists the remaining columns (with their descriptions) and clicking one adds it to the graph.
+
+The two checkboxes at the top left change what **+** fetches:
+
+- **Max depth for left (+) button** — instead of one level, fetch all the way to the upstream ends.
+- **Max depth for right (+) button** — same, downstream (shown in table mode only).
+
+### Canvas basics
+
+- **Pan** by dragging empty canvas, **zoom** with the mouse wheel; the bottom-left controls offer zoom in/out, **fit view**, and an interactivity lock.
+- **Drag a node** to reposition it. Dragged nodes keep their position — automatic re-layout won't move them anymore.
+- **Camera button** (bottom right) — copies the whole canvas to the clipboard as a PNG image, handy for pasting into docs or chat.
+- The thin bar on the right edge expands into a debug **sidebar** (zoom/pan transform and node coordinates).
+- An amber **"Lineage was truncated"** banner means the server stopped traversal because it exceeded the `MAX_LINEAGE_SECONDS` budget — the graph is partial. It does *not* appear for the intentional depth-1 default of table mode.
+
+## The CTE page (`/cte`)
+
+Reach it from the page switcher, or by clicking a table name (table mode) / column name (column mode) on `/cl`.
+
+The page splits in two:
+
+- **Left: compiled SQL** of the model (read-only, syntax highlighted).
+- **Right: tabs**
+  - **Description** — the model's description, rendered as markdown.
+  - **Columns** — name / type / description of every column.
+  - **Lineage** — the model's internal CTE graph. Clicking a CTE node scrolls the SQL editor to that CTE's definition. When you arrived with a column selected, highlights show the selected column (amber), the columns it feeds in the next step (emerald), and the next tables (indigo). Source names inside a CTE node are clickable and open their own `/cte` page.
+
+## Edit / design mode
+
+Edit mode turns the lineage canvas into a lightweight design (DFD) editor: sketch planned tables next to real ones, annotate, and share the result. Toggle it with the **pencil button** at the bottom right — a violet **EDIT MODE** badge appears at the bottom while it's on. Entering edit mode switches the view to column mode automatically.
+
+### Toolbar (top center)
+
+- **+ Table** — add a planned table at the center of the view: set its name, add/rename/remove columns, mark primary keys with the **PK** toggle (multiple PKs = composite key), and pick a materialization type. Select the node to reveal its delete (trash) button.
+- **+ Note** — add a sticky note for free-text annotations. Resize the text area as needed.
+- **Share** — copies a URL that reproduces the whole canvas (nodes, edges, positions, and view mode). The design is compressed into the URL itself, so very large designs are warned about (>2 KB) or blocked (>8 KB) — use Export then.
+- **Export** — downloads the design as `lineage-design.json` (no size limit; also nice for keeping designs in Git).
+- **Import** — loads a previously exported JSON file and replaces the current canvas with it.
+
+### Drawing connections
+
+Drag from a violet **column dot** on one node to a column dot on another to draw an edge. Hand-drawn edges render as dashed violet lines, so they're distinguishable from analyzed lineage. They connect real columns and designed columns alike.
+
+### Editing existing models
+
+Use **⋮ → Edit (design)** on a regular (analyzed) table node to convert it into an editable node — its existing edges are preserved, and you can then rename columns, add planned ones, or mark keys. This is the way to sketch "how this model should change".
+
+### Restoring a design
+
+Opening a **Share** URL (or importing a JSON) restores the snapshot exactly as it was — including manual node positions and the view mode — without re-querying the lineage API. From there you can keep editing, or expand real lineage around the design as usual.
+
+## Looker mode (optional)
+
+When the frontend is built with `NEXT_PUBLIC_USE_LOOKER=true` (and the Looker analysis JSON exists — see the README), the search dialog on `/cl` gains **dbt / looker** tabs:
+
+- **looker** replaces the schema/source pickers with a dashboard picker (grouped by folder).
+- The resulting graph shows **dashboard nodes** whose elements link back to Looker (click the dashboard title or an element to open it), wired to the dbt tables they consume.
+
+## Deep links
+
+`/cl` accepts query parameters, so a lineage view can be bookmarked or generated (the `dbt-column-lineage run-params` CLI command does exactly this from your git diff):
+
+| Param | Meaning |
+|-------|---------|
+| `schema` | schema name |
+| `sources` | comma-separated model names |
+| `activeSource` | which source the column picker focuses |
+| `selectedColumns` | JSON object `{"model": ["col", …]}` |
+| `showColumn` | `true` = column mode, `false` = table mode |
+| `depth` | traversal depth (`-1` = unlimited) |
+| `design` | a compressed design snapshot (from **Share**) — when present, everything else is ignored and the snapshot is restored as-is |
+
+`/cte` accepts `schema`, `sources`, `activeSource`, and `selectedColumns` for a single model.
+
+## Design snapshot JSON — generating designs programmatically
+
+The `?design=` restore path is fully self-contained: it does not call the lineage API and does not depend on the local dbt project's state. That means a design can be authored **without the UI at all** — by a script, a CI job, or an LLM agent — and delivered as a URL. A typical use: an automated dbt PR includes a design link so reviewers can open the proposed model layout locally with `dbt-column-lineage run`.
+
+### Snapshot format
+
+The value of `?design=` (and the content of an Export/Import file) is this JSON, version 1:
+
+```json
+{
+  "v": 1,
+  "view": { "showColumn": true, "rankdir": "RL", "sourceMode": "dbt" },
+  "nodes": [
+    {
+      "id": "design-stg_payments",
+      "type": "editableTableNode",
+      "position": { "x": 0, "y": 0 },
+      "data": {
+        "name": "stg_payments",
+        "columns": ["payment_id", "order_id", "amount"],
+        "pks": ["payment_id"],
+        "materialized": "view",
+        "custom": true,
+        "manual": true
+      }
+    },
+    {
+      "id": "design-fct_payments",
+      "type": "editableTableNode",
+      "position": { "x": 400, "y": 40 },
+      "data": {
+        "name": "fct_payments",
+        "columns": ["order_id", "total_amount"],
+        "pks": ["order_id"],
+        "materialized": "incremental",
+        "custom": true,
+        "manual": true
+      }
+    },
+    {
+      "id": "note-1",
+      "type": "noteNode",
+      "position": { "x": 400, "y": -100 },
+      "data": { "text": "Proposed in PR #123", "custom": true, "manual": true }
+    }
+  ],
+  "edges": [
+    {
+      "id": "e1",
+      "source": "design-fct_payments",
+      "target": "design-stg_payments",
+      "sourceHandle": "order_id__source",
+      "targetHandle": "order_id__target",
+      "data": { "custom": true },
+      "style": { "stroke": "#7c3aed", "strokeDasharray": "6 4" }
+    }
+  ]
+}
+```
+
+Rules:
+
+- **`view`** — use `{"showColumn": true, "rankdir": "RL", "sourceMode": "dbt"}` for hand-authored designs. The view settings must match the handles your edges reference, so don't change them unless you know why.
+- **Node types** — author with `editableTableNode` (a planned/designed table) and `noteNode` (annotation). `tableNode` / `dashboardNode` also round-trip (they appear when you export an analyzed graph) but aren't meant to be written by hand.
+- **`editableTableNode.data`** — `name` (string), `columns` (string array), optional `pks` (subset of `columns`; multiple = composite key), optional `materialized` (`table` | `view` | `incremental` | `snapshot` | `seed`, default `table`). Always set `custom: true, manual: true`.
+- **`position` is required** and is frozen on restore — there is no auto-layout for snapshots. A simple recipe: upstream models on the left, ~400 px per dependency layer in `x`, ~200–250 px between tables in `y`.
+- **Edges point downstream → upstream**, matching how analyzed lineage edges are stored: `source` is the *consuming* model's node id with `sourceHandle: "<column>__source"`, `target` is the upstream model's node id with `targetHandle: "<column>__target"`. Column names in handle ids must exactly match entries in `data.columns`. Include the `style` shown above to get the dashed-violet "designed edge" look.
+- A malformed snapshot fails safe: the page shows *"Invalid or corrupted design URL"* and renders nothing.
+
+### Building the URL
+
+The `design` parameter is the JSON compressed with [lz-string](https://github.com/pieroxy/lz-string)'s `compressToEncodedURIComponent`:
+
+```bash
+# Node
+node -e "console.log(require('lz-string').compressToEncodedURIComponent(require('fs').readFileSync('design.json','utf8')))"
+
+# Python (pip install lzstring — output is compatible with the JS library)
+python3 -c "import lzstring,sys; print(lzstring.LZString().compressToEncodedURIComponent(open('design.json').read()))"
+```
+
+Then launch the packaged app and open the link (the pip-installed app serves the UI and API on one port, default 5000):
+
+```bash
+dbt-column-lineage run   # http://127.0.0.1:5000
+# open http://127.0.0.1:5000/cl?design=<encoded>
+```
+
+A small design (a few tables) encodes to well under 1 KB. Keep URLs under ~8 KB; beyond that, ship the JSON file itself and load it via **Edit mode → Import** instead.
+
+Since the page renders without any interaction, a headless browser can also screenshot the result — e.g. to attach a static preview image to a PR alongside the link.

--- a/frontend/src/components/organisms/Sidebar.tsx
+++ b/frontend/src/components/organisms/Sidebar.tsx
@@ -1,7 +1,7 @@
 'use client'
 import { useRouter } from 'next/navigation'
 import { useCallback, useEffect, useState } from 'react'
-import { Edge, Node, Position, ReactFlowState, useReactFlow, useStore } from '@xyflow/react'
+import { Edge, Node, Position, ReactFlowState, useReactFlow, useStore, useStoreApi } from '@xyflow/react'
 import { useStore as useStoreZustand } from '@/store/zustand'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faAngleRight, faAngleLeft } from '@fortawesome/free-solid-svg-icons'
@@ -69,9 +69,9 @@ const getLayoutedElements = (nodes: Node[], edges: Edge[], options: {rankdir: st
 
 export const Sidebar = ({setNodes, setEdges, setViewIsFit, nodesPositioned, setNodesPositioned}: DagreNodePositioningProps) => {
   const { fitView } = useReactFlow()
+  const storeApi = useStoreApi()
   const nodeInternals = useStore((state: ReactFlowState) => state.nodeLookup)
   const flattenedNodes = Array.from(nodeInternals.values())
-  const edges = useStore((state: ReactFlowState) => state.edges)
   const transform = useStore((state: ReactFlowState) => state.transform)
   const options = useStoreZustand((state) => state.options)
   const sidebarActive = useStoreZustand((state) => state.sidebarActive)
@@ -88,15 +88,20 @@ export const Sidebar = ({setNodes, setEdges, setViewIsFit, nodesPositioned, setN
 
   useEffect(() => {
     try {
+      // render 時のクロージャ(flattenedNodes/edges)は古い store を指していることがある:
+      // Import 直後は setNodes 済みでも StoreUpdater の同期前で、旧グラフでレイアウト→
+      // setNodes するとインポート内容を上書きしてしまう。effect 実行時点の最新 state を読む。
+      const { nodeLookup, edges } = storeApi.getState()
+      const currentNodes = Array.from(nodeLookup.values())
       // node dimensions are not immediately detected, so we want to wait until they are
-      if (flattenedNodes[0]?.measured?.width) {
+      if (currentNodes[0]?.measured?.width) {
 
         // use dagre graph to layout nodes
 
         // if nodes exist and nodes are not positioned
         // console.log(nodesPositioned)
-        if (flattenedNodes.length > 0 && !nodesPositioned) {
-          const layouted = getLayoutedElements(flattenedNodes, edges, options)
+        if (currentNodes.length > 0 && !nodesPositioned) {
+          const layouted = getLayoutedElements(currentNodes, edges, options)
 
           console.log('redraw', layouted)
           // update react flow state

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,8 @@ dependencies = [
 classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,0 @@
-sqlglot==30.11.0
-fastapi==0.136.3
-uvicorn==0.49.0
-requests==2.34.2
-pytz==2026.2
-looker-sdk==26.10.0
-itsdangerous==2.2.0
-typer==0.26.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-sqlglot==30.10.0
+sqlglot==30.11.0
 fastapi==0.136.3
 uvicorn==0.49.0
 requests==2.34.2

--- a/src/dbt_column_lineage/lineage.py
+++ b/src/dbt_column_lineage/lineage.py
@@ -378,7 +378,9 @@ class DbtSqlglot:
     def __is_phantom_cte_label(self, label: str, cte_names: set, source: str) -> bool:
         """label が「解析中クエリの CTE 名」かつ「実在 dbt オブジェクトでない」場合のみ phantom とみなす。
         UNPIVOT 等で sqlglot が CTE をテーブル末端として誤って返す(sqlglot#7727)ケースを除外する。
-        実在モデル名と同名の CTE(ref ラップ)は実テーブルとして残す。"""
+        実在モデル名と同名の CTE(ref ラップ)は実テーブルとして残す。
+        #7727 は sqlglot 30.11.0 で修正済み(それ以降 phantom は発生せずこのフィルタは素通り)だが、
+        パッケージは sqlglot>=30,<31 を許容するため、下限を 30.11 以上に上げるまでは残す。"""
         if not (cte_names and label.lower() in cte_names):
             return False
         if label.lower() in self.__real_dbt_object_names():

--- a/test/unit/test_sqlglot_unpivot_regression.py
+++ b/test/unit/test_sqlglot_unpivot_regression.py
@@ -1,15 +1,24 @@
-"""Regression guard for the upstream sqlglot UNPIVOT lineage limitation
+"""Regression guard for sqlglot's UNPIVOT lineage
 (https://github.com/tobymao/sqlglot/issues/7727).
 
-sqlglot's lineage() does not expand an UNPIVOT's value/name columns to the
-columns listed in `IN (...)`; instead it terminates at the input relation with a
-column that does not exist there (a "phantom"). Our `DbtSqlglot` filters those
-phantom CTE nodes out. If sqlglot fixes this, the assertion below flips and this
-test fails — a signal to revisit / drop the workaround in lineage.py.
+Before sqlglot 30.11.0, lineage() did not expand an UNPIVOT's value/name
+columns to the columns listed in `IN (...)`; it terminated at the input
+relation with a column that does not exist there (a "phantom"). #7727 was
+fixed in sqlglot 30.11.0 — this guard originally asserted the broken
+behavior and fired on that release; it now asserts the fixed behavior so a
+re-regression is caught.
+
+Note `DbtSqlglot`'s phantom-CTE filter in lineage.py is still in place: the
+package allows sqlglot >=30,<31 (pyproject), so installs on <30.11 still
+produce phantoms. Drop the filter when the lower bound moves past 30.11.
 """
+import pytest
+import sqlglot
 from sqlglot import exp
 from sqlglot.lineage import lineage
 
+
+SQLGLOT_VERSION = tuple(int(p) for p in sqlglot.__version__.split(".")[:2])
 
 UNPIVOT_SQL = """
 WITH src AS (
@@ -27,19 +36,21 @@ def _leaf_table_names(col):
             if isinstance(n.expression, exp.Table) and not n.downstream]
 
 
-def test_unpivot_value_column_does_not_fan_out_to_sources():
-    # 現状(sqlglot#7727): score は元列 sales.jan / sales.feb に展開されず、
-    # 入力CTE `src` の存在しない列 `SRC.SCORE` で終端する。
+@pytest.mark.skipif(
+    SQLGLOT_VERSION < (30, 11),
+    reason="sqlglot <30.11 has the #7727 UNPIVOT limitation (handled by the phantom-CTE filter)",
+)
+def test_unpivot_value_column_fans_out_to_sources():
+    # sqlglot 30.11.0 (#7727 修正後): score は UNPIVOT の IN (...) に列挙された
+    # 元列 sales.jan / sales.feb まで正しく展開される。
     leaves = _leaf_table_names("score")
-    assert leaves == ["SRC.SCORE"], (
-        f"sqlglot UNPIVOT lineage may have been fixed (#7727): got {leaves}. "
-        "Revisit the phantom-CTE filter in lineage.py."
+    assert leaves == ["SALES.JAN", "SALES.FEB"], (
+        f"sqlglot UNPIVOT lineage regressed (#7727): got {leaves}."
     )
 
 
 def test_plain_cte_traces_normally():
     # 対照: UNPIVOT を含まない素の CTE なら sqlglot は実テーブル sales まで辿れる。
-    # (=問題は UNPIVOT 固有。UNPIVOT を含む relation では id すら CTE で止まる。)
     plain_sql = "WITH s AS (SELECT id, jan FROM sales) SELECT id, jan FROM s"
     node = lineage("id", plain_sql, schema={"sales": {"id": "int", "jan": "int"}}, dialect="snowflake")
     leaves = [n.name for n in node.walk()


### PR DESCRIPTION
## Summary

### Bug fix — edit-mode Import did nothing on a loaded graph
Importing a design JSON while lineage was already displayed silently reverted to the pre-import graph (added/planned tables disappeared). Export was fine; the import was being overwritten.

**Root cause**: `applySnapshot` sets the imported nodes and `nodesPositioned=false` in the same commit, but the dagre layout effect in `Sidebar.tsx` used `flattenedNodes`/`edges` captured at render time — still pointing at the pre-import React Flow store (props→store sync happens in `StoreUpdater`'s effect, after render). The effect then ran `setNodes(layouted-old-nodes)`, wiping the snapshot.

**Fix**: read `nodeLookup`/`edges` from the store at effect execution time (`useStoreApi().getState()`); by then `StoreUpdater` has synced. Trigger deps are unchanged, so the normal fetch→layout flow is unaffected.

### Docs — UI guide, linked from README
New `docs/ui-guide.md` covering every operation: search dialog, node anatomy, +/- lineage expansion, depth checkboxes, the CTE page, Looker mode, edit/design mode, and deep-link query params.

It also specifies the **design snapshot JSON format** and how to build a `?design=` URL programmatically (lz-string / Python `lzstring` one-liners). Since `?design=` restores without touching the API, designs can be generated **without the UI** — e.g. CI or an LLM agent can attach a design link (plus a headless screenshot) to an automated dbt PR.

## Test plan
- [x] `npm run lint` (0 warnings) / `tsc --noEmit` pass
- [x] Playwright against the demo project: repro (load lineage → edit → add table → export → reload → import) loses the added table **pre-fix**, restores all nodes/names/columns **post-fix**
- [x] Doc spec verified end-to-end: extracted the guide's example JSON, built the URL with the documented Python one-liner, opened it with zero UI interaction — all 3 nodes + column edge render; Python `lzstring` output confirmed compatible with the JS `lz-string` restore path

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Addendum — UNPIVOT canary fired in CI (sqlglot 30.11.0)

The first CI run failed on `test_unpivot_value_column_does_not_fan_out_to_sources` — the intentional regression guard that fails when upstream sqlglot fixes UNPIVOT lineage ([sqlglot#7727](https://github.com/tobymao/sqlglot/issues/7727)). CI resolved **sqlglot 30.11.0** (within our `>=30,<31` range), which fixes the issue: `score` now fans out to `sales.jan` / `sales.feb`. Unrelated to this PR — main's CI would fail the same way.

Third commit flips the canary to assert the fixed behavior (skipped on sqlglot <30.11), keeps the phantom-CTE filter (still needed for 30.x < 30.11 installs; no-op on >=30.11), and bumps the dev pin to 30.11.0. Suite verified locally on both 30.10.0 (26 passed, 1 skipped) and 30.11.0 (27 passed).


## Addendum 2 — dependency single-sourcing & Python 3.13/3.14

- **`requirements.txt` removed** — it duplicated `[project.dependencies]` and had drifted. The Dockerfile deps layer now extracts `[project.dependencies]` from `pyproject.toml` via `tomllib` (layer still caches on pyproject alone); `looker-sdk` is no longer baked into the image since the runtime never imports it (stays in the `[looker]` extra for `tools/looker_analyzer.py`). README / CLAUDE.md dev setup switched to `pip install -e ".[dev]"`. Verified: `python-builder` stage builds and all runtime deps import.
- **CI matrix extended to Python 3.13 / 3.14**, with matching trove classifiers. Suite verified on `python:3.14` in Docker before push; all four versions pass in CI.
